### PR TITLE
Rely on external callers marking shards available

### DIFF
--- a/services/placement/placement.go
+++ b/services/placement/placement.go
@@ -80,6 +80,10 @@ func (p placement) NumShards() int {
 	return len(p.shards)
 }
 
+func (p placement) String() string {
+	return services.PlacementInstances(p.instances).String()
+}
+
 // Validate validates a placement
 func Validate(p services.ServicePlacement) error {
 	shardCountMap := convertShardSliceToMap(p.Shards())

--- a/services/placement/placement.go
+++ b/services/placement/placement.go
@@ -163,7 +163,9 @@ type instance struct {
 }
 
 func (i *instance) String() string {
-	return fmt.Sprintf("[id:%s, rack:%s, zone:%s, weight:%v]", i.id, i.rack, i.zone, i.weight)
+	return fmt.Sprintf(
+		"Instance<ID=%s, Rack=%s, Zone=%s, Weight=%d, Shards=%s>",
+		i.id, i.rack, i.zone, i.weight, i.shards.String())
 }
 
 func (i *instance) ID() string {

--- a/services/placement/placement_test.go
+++ b/services/placement/placement_test.go
@@ -21,6 +21,7 @@
 package placement
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -220,7 +221,12 @@ func TestValidate(t *testing.T) {
 }
 
 func TestInstance(t *testing.T) {
-	h1 := NewInstance().SetID("id").SetEndpoint("endpoint").SetRack("rack").SetWeight(1).SetZone("zone")
+	h1 := NewInstance().
+		SetID("id").
+		SetEndpoint("endpoint").
+		SetRack("rack").
+		SetWeight(1).
+		SetZone("zone")
 	assert.NotNil(t, h1.Shards())
 	s := shard.NewShards([]shard.Shard{
 		shard.NewShard(1).SetState(shard.Available),
@@ -228,7 +234,10 @@ func TestInstance(t *testing.T) {
 		shard.NewShard(3).SetState(shard.Available),
 	})
 	h1.SetShards(s)
-	assert.Equal(t, "[id:id, rack:rack, zone:zone, weight:1]", h1.String())
+	description := fmt.Sprintf(
+		"Instance<ID=id, Rack=rack, Zone=zone, Weight=1, Shards=%s>",
+		"Shards<Initializing=[], Available=[1 2 3], Leaving=[]>")
+	assert.Equal(t, description, h1.String())
 
 	assert.True(t, h1.Shards().Contains(1))
 	assert.False(t, h1.Shards().Contains(100))

--- a/services/placement/service/placementservice_test.go
+++ b/services/placement/service/placementservice_test.go
@@ -42,8 +42,8 @@ func TestGoodWorkflow(t *testing.T) {
 	p := NewPlacementService(NewMockStorage(), testServiceID(), placement.NewOptions())
 	testGoodWorkflow(t, p)
 
-	// p = NewPlacementService(NewMockStorage(), testServiceID(), placement.NewOptions().SetLooseRackCheck(true))
-	// testGoodWorkflow(t, p)
+	p = NewPlacementService(NewMockStorage(), testServiceID(), placement.NewOptions().SetLooseRackCheck(true))
+	testGoodWorkflow(t, p)
 }
 
 func testGoodWorkflow(t *testing.T, p services.PlacementService) {

--- a/services/placement/service/placementservice_test.go
+++ b/services/placement/service/placementservice_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3cluster/services/placement"
 	"github.com/m3db/m3cluster/shard"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testServiceID() services.ServiceID {
@@ -41,8 +42,8 @@ func TestGoodWorkflow(t *testing.T) {
 	p := NewPlacementService(NewMockStorage(), testServiceID(), placement.NewOptions())
 	testGoodWorkflow(t, p)
 
-	p = NewPlacementService(NewMockStorage(), testServiceID(), placement.NewOptions().SetLooseRackCheck(true))
-	testGoodWorkflow(t, p)
+	// p = NewPlacementService(NewMockStorage(), testServiceID(), placement.NewOptions().SetLooseRackCheck(true))
+	// testGoodWorkflow(t, p)
 }
 
 func testGoodWorkflow(t *testing.T, p services.PlacementService) {
@@ -55,11 +56,20 @@ func testGoodWorkflow(t *testing.T, p services.PlacementService) {
 	_, err = p.AddReplica()
 	assert.NoError(t, err)
 
+	for _, instance := range []services.PlacementInstance{h1, h2} {
+		err = p.MarkInstanceAvailable(instance.ID())
+		assert.NoError(t, err)
+	}
 	_, err = p.AddInstance([]services.PlacementInstance{h3})
+	assert.NoError(t, err)
+
+	err = p.MarkInstanceAvailable(h3.ID())
 	assert.NoError(t, err)
 
 	_, err = p.RemoveInstance(h1.ID())
 	assert.NoError(t, err)
+
+	markAllInstancesAvailable(t, p)
 
 	_, err = p.ReplaceInstance(
 		h2.ID(),
@@ -71,6 +81,12 @@ func testGoodWorkflow(t *testing.T, p services.PlacementService) {
 		},
 	)
 	assert.NoError(t, err)
+
+	for _, id := range []string{"h21", "h4"} {
+		err = p.MarkInstanceAvailable(id)
+		assert.NoError(t, err)
+	}
+
 	s, err := p.Placement()
 	assert.NoError(t, err)
 	assert.Equal(t, 3, s.NumInstances())
@@ -701,4 +717,28 @@ func (ms *mockStorage) Placement(service services.ServiceID) (services.ServicePl
 	}
 
 	return nil, 0, errors.New("placement not exist")
+}
+
+func markAllInstancesAvailable(
+	t *testing.T,
+	ps services.PlacementService,
+) {
+	p, err := ps.Placement()
+	require.NoError(t, err)
+	for _, i := range p.Instances() {
+		if len(i.Shards().ShardsForState(shard.Initializing)) == 0 {
+			continue
+		}
+		err := ps.MarkInstanceAvailable(i.ID())
+		require.NoError(t, err)
+	}
+}
+
+func placementToString(
+	t *testing.T,
+	ps services.PlacementService,
+) string {
+	p, err := ps.Placement()
+	require.NoError(t, err)
+	return services.PlacementInstances(p.Instances()).String()
 }

--- a/services/placement/service/placementservice_test.go
+++ b/services/placement/service/placementservice_test.go
@@ -733,12 +733,3 @@ func markAllInstancesAvailable(
 		require.NoError(t, err)
 	}
 }
-
-func placementToString(
-	t *testing.T,
-	ps services.PlacementService,
-) string {
-	p, err := ps.Placement()
-	require.NoError(t, err)
-	return services.PlacementInstances(p.Instances()).String()
-}

--- a/services/services.go
+++ b/services/services.go
@@ -22,6 +22,7 @@ package services
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/m3db/m3cluster/shard"
 )
@@ -139,3 +140,19 @@ type queryOptions struct {
 
 func (qo *queryOptions) IncludeUnhealthy() bool                  { return qo.includeUnhealthy }
 func (qo *queryOptions) SetIncludeUnhealthy(h bool) QueryOptions { qo.includeUnhealthy = h; return qo }
+
+// PlacementInstances is a slice of instances that can produce a debug string
+type PlacementInstances []PlacementInstance
+
+func (i PlacementInstances) String() string {
+	if len(i) == 0 {
+		return "[]"
+	}
+	var strs []string
+	strs = append(strs, "[\n")
+	for _, elem := range i {
+		strs = append(strs, "\t"+elem.String()+",\n")
+	}
+	strs = append(strs, "]")
+	return strings.Join(strs, "")
+}

--- a/services/types.go
+++ b/services/types.go
@@ -185,6 +185,9 @@ type ServicePlacement interface {
 
 	// ShardsLen returns the number of shards in a replica
 	NumShards() int
+
+	// String returns a description of the placement
+	String() string
 }
 
 // PlacementInstance represents an instance in a service placement


### PR DESCRIPTION
cc @cw9 @xichen2020 @martin-mao @ben-lerner @prateek 

Outstanding question for @cw9 : when do the leaving shards get removed and then also when is instance completely taken out of the placement?  What calls to the `PlacementService` achieve this?