### PR TITLE
Modify ConfigServiceClient interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,8 +29,8 @@ import (
 // access to cluster services
 type Client interface {
 	// Services returns access to the set of services
-	Services() services.Services
+	Services() (services.Services, error)
 
 	// KV returns access to the distributed configuration store
-	KV() kv.Store
+	KV() (kv.Store, error)
 }

--- a/client/mock_client.go
+++ b/client/mock_client.go
@@ -50,20 +50,22 @@ func (_m *MockClient) EXPECT() *_MockClientRecorder {
 	return _m.recorder
 }
 
-func (_m *MockClient) KV() kv.Store {
+func (_m *MockClient) KV() (kv.Store, error) {
 	ret := _m.ctrl.Call(_m, "KV")
 	ret0, _ := ret[0].(kv.Store)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockClientRecorder) KV() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "KV")
 }
 
-func (_m *MockClient) Services() services.Services {
+func (_m *MockClient) Services() (services.Services, error) {
 	ret := _m.ctrl.Call(_m, "Services")
 	ret0, _ := ret[0].(services.Services)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockClientRecorder) Services() *gomock.Call {

--- a/services/mock_services.go
+++ b/services/mock_services.go
@@ -810,10 +810,11 @@ func (_mr *_MockServicePlacementRecorder) NumInstances() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NumInstances")
 }
 
-func (_m *MockServicePlacement) Instance(id string) PlacementInstance {
+func (_m *MockServicePlacement) Instance(id string) (PlacementInstance, bool) {
 	ret := _m.ctrl.Call(_m, "Instance", id)
 	ret0, _ := ret[0].(PlacementInstance)
-	return ret0
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
 func (_mr *_MockServicePlacementRecorder) Instance(arg0 interface{}) *gomock.Call {
@@ -848,6 +849,16 @@ func (_m *MockServicePlacement) NumShards() int {
 
 func (_mr *_MockServicePlacementRecorder) NumShards() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NumShards")
+}
+
+func (_m *MockServicePlacement) String() string {
+	ret := _m.ctrl.Call(_m, "String")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockServicePlacementRecorder) String() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "String")
 }
 
 // Mock of PlacementInstance interface


### PR DESCRIPTION
Some config service client user only needs a KV client or a Services
client, not both. This interface change allows us to create those
clients lazily.