### PR TITLE
No longer pin m3x to a certain version in glide

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ae5c127a48fafa2da20ddc41151e5a108e7f3254074adf3ab66ff285b7636afd
-updated: 2016-09-01T14:12:12.96861304-04:00
+hash: 29e2df8267349dba733160bef18d3e0fe56958f96d8170e49b576dcdf00875fa
+updated: 2016-12-20T13:45:13.885953389-05:00
 imports:
 - name: github.com/golang/mock
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
@@ -13,12 +13,20 @@ imports:
 - name: github.com/m3db/m3x
   version: bafb005b9448e769f5c565ae86270146917cc89b
   subpackages:
+  - close
   - log
   - watch
-  - close
 - name: github.com/stretchr/testify
   version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:
   - assert
   - require
-devImports: []
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,11 +9,6 @@ import:
   version: 7390af9dcd3c33042ebaf2474a1724a83cf1a7e6
   subpackages:
   - proto
-- package: github.com/m3db/m3x
-  version: bafb005b9448e769f5c565ae86270146917cc89b
-  subpackages:
-  - log
-  - watch
 - package: github.com/stretchr/testify
   version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:


### PR DESCRIPTION
Pinning m3x to a version seems unnecessary to me

@xichen2020 @robskillington 