### PR TITLE
Pin etcd to version release-3.1

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ffda1577c61167fffdd74876c6863637aeb26c1096bef3d917465d204db73897
-updated: 2016-12-27T12:18:49.08248771-05:00
+hash: e412e0809212e1bf3817418678a925ab4af9ac42cd251dc838e07deb0936facd
+updated: 2017-01-28T00:38:10.773685326-05:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -8,7 +8,7 @@ imports:
 - name: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
 - name: github.com/coreos/etcd
-  version: be740dc4362bf90d63650ddb809daf8f5abd16a6
+  version: 8ba2897a21e4fc51b298ca553d251318425f93ae
   subpackages:
   - alarm
   - auth
@@ -87,10 +87,6 @@ imports:
   version: 909568be09de550ed094403c2bf8a261b5bb730a
   subpackages:
   - proto
-- name: github.com/golang/groupcache
-  version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
-  subpackages:
-  - lru
 - name: github.com/golang/mock
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
@@ -113,6 +109,8 @@ imports:
   - utilities
 - name: github.com/jonboulle/clockwork
   version: 2eee05ed794112d45db504eb05aa693efd2b8b09
+- name: github.com/karlseguin/ccache
+  version: a2d62155777b39595c825ed3824279e642a5db3c
 - name: github.com/m3db/m3x
   version: 71d99ef2d83e52ded21c79eb1e5959195f29d7cf
   subpackages:
@@ -150,7 +148,7 @@ imports:
 - name: github.com/uber-go/tally
   version: 1f0f7171f312a8cff5f697fe5f4d45dbaec8c3ac
 - name: github.com/ugorji/go
-  version: 9c7f9b7a2bc3a520f7c7b30b34b7f85f47fe27b6
+  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
 - name: github.com/xiang90/probing
@@ -161,12 +159,14 @@ imports:
   - bcrypt
   - blowfish
 - name: golang.org/x/net
-  version: 6acef71eb69611914f7a30939ea9f6e194c78172
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
   - http2
   - http2/hpack
+  - idna
   - internal/timeseries
+  - lex/httplex
   - trace
 - name: golang.org/x/sys
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,7 +24,7 @@ import:
   - assert
   - require
 - package: github.com/coreos/etcd
-  version: be740dc4362bf90d63650ddb809daf8f5abd16a6
+  version: 8ba2897a21e4fc51b298ca553d251318425f93ae #release-3.1
   subpackages:
   - clientv3
   - integration


### PR DESCRIPTION
Pinning to a verified SHA in https://github.com/coreos/etcd/commits/release-3.1 since our etcd servers are upgraded to the 3.1 release
cc @xichen2020 @robskillington @pjjw 