### PR TITLE
Allow adding leaving instance back to placement

### DIFF
--- a/services/placement/algo/sharded.go
+++ b/services/placement/algo/sharded.go
@@ -162,7 +162,8 @@ func (a rackAwarePlacementAlgorithm) addInstance(p services.ServicePlacement, ad
 		if !placement.IsInstanceLeaving(instance) {
 			return nil, errAddingInstanceAlreadyExist
 		}
-		p, addingInstance = a.moveLeavingShardsBack(p, instance)
+		p = a.moveLeavingShardsBack(p, instance)
+		addingInstance = instance
 	}
 
 	ph := newAddInstanceHelper(p, addingInstance, a.opts)
@@ -182,7 +183,7 @@ func (a rackAwarePlacementAlgorithm) addInstance(p services.ServicePlacement, ad
 	return ph.GeneratePlacement(), nil
 }
 
-func (a rackAwarePlacementAlgorithm) moveLeavingShardsBack(p services.ServicePlacement, source services.PlacementInstance) (services.ServicePlacement, services.PlacementInstance) {
+func (a rackAwarePlacementAlgorithm) moveLeavingShardsBack(p services.ServicePlacement, source services.PlacementInstance) services.ServicePlacement {
 	ph := newAddInstanceHelper(p, source, a.opts)
 	instanceID := source.ID()
 	// since the instance does not know where did its shards go, we need to iterate the whole placement to find them
@@ -199,5 +200,5 @@ func (a rackAwarePlacementAlgorithm) moveLeavingShardsBack(p services.ServicePla
 		}
 	}
 
-	return ph.GeneratePlacement(), source
+	return ph.GeneratePlacement()
 }

--- a/services/placement/algo/sharded.go
+++ b/services/placement/algo/sharded.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3cluster/services/placement"
+	"github.com/m3db/m3cluster/shard"
 )
 
 var (
@@ -157,10 +158,13 @@ func (a rackAwarePlacementAlgorithm) ReplaceInstance(
 }
 
 func (a rackAwarePlacementAlgorithm) addInstance(p services.ServicePlacement, addingInstance services.PlacementInstance) (services.ServicePlacement, error) {
-	if _, exist := p.Instance(addingInstance.ID()); exist {
-		return nil, errAddingInstanceAlreadyExist
-
+	if instance, exist := p.Instance(addingInstance.ID()); exist {
+		if !placement.IsInstanceLeaving(instance) {
+			return nil, errAddingInstanceAlreadyExist
+		}
+		p, addingInstance = a.moveLeavingShardsBack(p, instance)
 	}
+
 	ph := newAddInstanceHelper(p, addingInstance, a.opts)
 	targetLoad := ph.TargetLoadForInstance(addingInstance.ID())
 	// try to take shards from the most loaded instances until the adding instance reaches target load
@@ -176,4 +180,24 @@ func (a rackAwarePlacementAlgorithm) addInstance(p services.ServicePlacement, ad
 	}
 
 	return ph.GeneratePlacement(), nil
+}
+
+func (a rackAwarePlacementAlgorithm) moveLeavingShardsBack(p services.ServicePlacement, source services.PlacementInstance) (services.ServicePlacement, services.PlacementInstance) {
+	ph := newAddInstanceHelper(p, source, a.opts)
+	instanceID := source.ID()
+	// since the instance does not know where did its shards go, we need to iterate the whole placement to find them
+	for _, other := range p.Instances() {
+		if other.ID() == instanceID {
+			continue
+		}
+		for _, s := range other.Shards().ShardsForState(shard.Initializing) {
+			if s.SourceID() == instanceID {
+				// NB(cw) in very rare case, the leaving shards could not be taken back
+				// but it's fine, the algo will fil up those load with other shards from the cluster
+				ph.MoveShard(s, other, source)
+			}
+		}
+	}
+
+	return ph.GeneratePlacement(), source
 }


### PR DESCRIPTION
Previously when adding an instance, we bail if the adding instance is already in placement,
this diff adds an exception if the existing instance is a leaving instance, meaning it has only Leaving shards.

This supports backing out of an instance removal operation.

The algo will first try taking those leaving shards back, and then do a normal addInstance if necessary to even the load.


@robskillington @xichen2020 