### PR TITLE
[placement] Add GetVersion() + SetVersion() funcs

### DIFF
--- a/services/client/storage.go
+++ b/services/client/storage.go
@@ -113,5 +113,8 @@ func (s *client) Placement(sid services.ServiceID) (services.ServicePlacement, i
 	}
 
 	p, err := PlacementFromProto(placementProto)
+	if p != nil {
+		p.SetVersion(v.Version())
+	}
 	return p, v.Version(), err
 }

--- a/services/client/storage_test.go
+++ b/services/client/storage_test.go
@@ -65,7 +65,7 @@ func TestPlacementStorage(t *testing.T) {
 	pGet, v, err := ps.Placement(sid)
 	require.NoError(t, err)
 	require.Equal(t, 1, v)
-	require.Equal(t, p, pGet)
+	require.Equal(t, p.SetVersion(1), pGet)
 
 	err = ps.CheckAndSet(sid, p, v)
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestPlacementStorage(t *testing.T) {
 	pGet, v, err = ps.Placement(sid)
 	require.NoError(t, err)
 	require.Equal(t, 2, v)
-	require.Equal(t, p, pGet)
+	require.Equal(t, p.SetVersion(2), pGet)
 
 	err = ps.Delete(sid)
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestPlacementStorage(t *testing.T) {
 	pGet, v, err = ps.Placement(sid)
 	require.NoError(t, err)
 	require.Equal(t, 1, v)
-	require.Equal(t, p, pGet)
+	require.Equal(t, p.SetVersion(1), pGet)
 
 	// different zone or different env are different services
 	_, _, err = ps.Placement(services.NewServiceID().SetName("m3db").SetEnvironment("env"))

--- a/services/mock_services.go
+++ b/services/mock_services.go
@@ -1136,6 +1136,26 @@ func (_mr *_MockServicePlacementRecorder) String() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "String")
 }
 
+func (_m *MockServicePlacement) GetVersion() int {
+	ret := _m.ctrl.Call(_m, "GetVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+func (_mr *_MockServicePlacementRecorder) GetVersion() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetVersion")
+}
+
+func (_m *MockServicePlacement) SetVersion(v int) ServicePlacement {
+	ret := _m.ctrl.Call(_m, "SetVersion", v)
+	ret0, _ := ret[0].(ServicePlacement)
+	return ret0
+}
+
+func (_mr *_MockServicePlacementRecorder) SetVersion(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetVersion", arg0)
+}
+
 // Mock of PlacementInstance interface
 type MockPlacementInstance struct {
 	ctrl     *gomock.Controller

--- a/services/placement/placement.go
+++ b/services/placement/placement.go
@@ -46,6 +46,7 @@ type placement struct {
 	rf        int
 	shards    []uint32
 	isSharded bool
+	version   int
 }
 
 func (p *placement) Instances() []services.PlacementInstance {
@@ -103,6 +104,15 @@ func (p *placement) IsSharded() bool {
 
 func (p *placement) SetIsSharded(v bool) services.ServicePlacement {
 	p.isSharded = v
+	return p
+}
+
+func (p *placement) GetVersion() int {
+	return p.version
+}
+
+func (p *placement) SetVersion(v int) services.ServicePlacement {
+	p.version = v
 	return p
 }
 

--- a/services/placement/placement_test.go
+++ b/services/placement/placement_test.go
@@ -341,6 +341,14 @@ func TestSortInstanceByID(t *testing.T) {
 	assert.Equal(t, []services.PlacementInstance{i1, i2, i3, i4, i5, i6}, i)
 }
 
+func TestVersion(t *testing.T) {
+	p1 := NewPlacement()
+	assert.Equal(t, 0, p1.GetVersion())
+
+	p1 = p1.SetVersion(100)
+	assert.Equal(t, 100, p1.GetVersion())
+}
+
 func TestOptions(t *testing.T) {
 	o := NewOptions()
 	assert.False(t, o.LooseRackCheck())

--- a/services/types.go
+++ b/services/types.go
@@ -262,6 +262,16 @@ type ServicePlacement interface {
 
 	// String returns a description of the placement
 	String() string
+
+	// GetVersion() returns the version of the placement retreived from the
+	// backing MVCC store.
+	GetVersion() int
+
+	// SetVersion() sets the version of the placement object. Since version
+	// is determined by the backing MVCC store, calling this method has no
+	// effect in terms of the updated ServicePlacement that is written back
+	// to the MVCC store.
+	SetVersion(v int) ServicePlacement
 }
 
 // PlacementInstance represents an instance in a service placement


### PR DESCRIPTION
In some placement-related methods we return the version of the key/value
pair in etcd along with the `ServicePlacement` (for example from
`PlacementService.Placement()`). There are cases where it's useful to
have the version follow that `ServicePlacement` object, so this expands
that interface to provide access to the version.

RFR @cw9 