### PR TITLE
Change KeyFn() to ApplyPrefix() in etcd kv options

### DIFF
--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -43,7 +43,7 @@ import (
 const (
 	keySeparator    = "/"
 	cacheFileFormat = "%s-%s.json"
-	kvPrefix        = "_kv"
+	kvPrefix        = "_kv/"
 )
 
 type newClientFn func(endpoints []string) (*clientv3.Client, error)
@@ -210,7 +210,7 @@ func fileName(appID, zone string) string {
 }
 
 func prefix(env string) string {
-	res := concat(kvPrefix, keySeparator)
+	res := kvPrefix
 	if env != "" {
 		res = concat(res, concat(env, keySeparator))
 	}

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -23,6 +23,7 @@ package etcd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -40,7 +41,7 @@ import (
 )
 
 const (
-	keyFormat       = "%s/%s"
+	keySeparator    = "/"
 	cacheFileFormat = "%s-%s.json"
 	kvPrefix        = "_kv"
 )
@@ -128,12 +129,7 @@ func (c *csclient) newKVStore() (kv.Store, error) {
 			SetLogger(c.logger).
 			SetMetricsScope(c.kvScope),
 		).
-		SetKeyFn(func(key string) string {
-			if env != "" {
-				key = fmt.Sprintf(keyFormat, env, key)
-			}
-			return fmt.Sprintf(keyFormat, kvPrefix, key)
-		}),
+		SetPrefix(prefix(env)),
 	)
 	return kvGen(c.opts.Zone())
 }
@@ -148,7 +144,7 @@ func (c *csclient) kvGen(kvOpts etcdKV.Options) sdClient.KVGen {
 
 			return etcdKV.NewStore(
 				cli,
-				kvOpts.SetCacheFilePath(cacheFileForZone(c.opts.CacheDir(), kvOpts.KeyFn()(c.opts.AppID()), zone)),
+				kvOpts.SetCacheFilePath(cacheFileForZone(c.opts.CacheDir(), kvOpts.ApplyPrefix(c.opts.AppID()), zone)),
 			)
 		},
 	)
@@ -204,12 +200,23 @@ func cacheFileForZone(cacheDir, appID, zone string) string {
 	if cacheDir == "" || appID == "" || zone == "" {
 		return ""
 	}
-
-	return fmt.Sprintf(keyFormat, cacheDir, fileName(appID, zone))
+	return filepath.Join(cacheDir, fileName(appID, zone))
 }
 
 func fileName(appID, zone string) string {
 	cacheFileName := fmt.Sprintf(cacheFileFormat, appID, zone)
 
 	return strings.Replace(cacheFileName, string(os.PathSeparator), "_", -1)
+}
+
+func prefix(env string) string {
+	res := concat(kvPrefix, keySeparator)
+	if env != "" {
+		res = concat(res, concat(env, keySeparator))
+	}
+	return res
+}
+
+func concat(a, b string) string {
+	return fmt.Sprintf("%s%s", a, b)
 }

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -147,6 +147,11 @@ func TestCacheFileForZone(t *testing.T) {
 	assert.Equal(t, "/dir/a_b-c_d.json", cacheFileForZone("/dir", "a/b", "c/d"))
 }
 
+func TestPrefix(t *testing.T) {
+	assert.Equal(t, "_kv/test/", prefix("test"))
+	assert.Equal(t, "_kv/", prefix(""))
+}
+
 func testOptions() Options {
 	return NewOptions().SetClusters([]Cluster{
 		NewCluster().SetZone("zone1").SetEndpoints([]string{"i1"}),

--- a/kv/etcd/store_test.go
+++ b/kv/etcd/store_test.go
@@ -649,9 +649,7 @@ func testStore(t *testing.T) (*clientv3.Client, Options, func()) {
 
 	opts := NewOptions().
 		SetWatchChanCheckInterval(10 * time.Millisecond).
-		SetKeyFn(func(key string) string {
-			return fmt.Sprintf("test/%s", key)
-		})
+		SetPrefix("test/")
 
 	return ec, opts, closer
 }

--- a/services/client/services_test.go
+++ b/services/client/services_test.go
@@ -22,7 +22,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -701,9 +700,7 @@ func testSetup(t *testing.T) (Options, func(), *mockHBGen) {
 			ec,
 			etcdKV.NewOptions().
 				SetWatchChanCheckInterval(100*time.Millisecond).
-				SetKeyFn(func(key string) string {
-					return fmt.Sprintf("[%s][%s]", zone, key)
-				}),
+				SetPrefix(zone+"/"),
 		)
 	}
 

--- a/services/client/services_test.go
+++ b/services/client/services_test.go
@@ -22,6 +22,7 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -700,7 +701,7 @@ func testSetup(t *testing.T) (Options, func(), *mockHBGen) {
 			ec,
 			etcdKV.NewOptions().
 				SetWatchChanCheckInterval(100*time.Millisecond).
-				SetPrefix(zone+"/"),
+				SetPrefix(fmt.Sprintf("%s/", zone)),
 		)
 	}
 


### PR DESCRIPTION
Remove the KeyFn() in the kv options and add ApplyPrefix() to prevent
users from adding suffix to the key, which might cause issues in etcd
usage in the future

For example: etcd allows adding a WithPrefix() in the Get calls, but if
the key we passed in was wrapped with a suffix, the result might be
confusing.

@xichen2020 @robskillington @schallert @prateek 