### PR TITLE
Fix bug in backing out of a replace

### DIFF
--- a/services/placement/algo/sharded.go
+++ b/services/placement/algo/sharded.go
@@ -51,7 +51,7 @@ func (a rackAwarePlacementAlgorithm) InitialPlacement(instances []services.Place
 	if err := ph.PlaceShards(newShards(shards), nil); err != nil {
 		return nil, err
 	}
-	return ph.GeneratePlacement(), nil
+	return ph.GeneratePlacement(false), nil
 }
 
 func (a rackAwarePlacementAlgorithm) AddReplica(p services.ServicePlacement) (services.ServicePlacement, error) {
@@ -64,7 +64,7 @@ func (a rackAwarePlacementAlgorithm) AddReplica(p services.ServicePlacement) (se
 	if err := ph.PlaceShards(newShards(p.Shards()), nil); err != nil {
 		return nil, err
 	}
-	return ph.GeneratePlacement(), nil
+	return ph.GeneratePlacement(false), nil
 }
 
 func (a rackAwarePlacementAlgorithm) RemoveInstance(p services.ServicePlacement, instanceID string) (services.ServicePlacement, error) {
@@ -82,7 +82,7 @@ func (a rackAwarePlacementAlgorithm) RemoveInstance(p services.ServicePlacement,
 		return nil, err
 	}
 
-	result, _, err := addInstanceToPlacement(ph.GeneratePlacement(), leavingInstance, false)
+	result, _, err := addInstanceToPlacement(ph.GeneratePlacement(false), leavingInstance, false)
 	return result, err
 }
 
@@ -125,7 +125,7 @@ func (a rackAwarePlacementAlgorithm) ReplaceInstance(
 	}
 
 	if loadOnInstance(leavingInstance) == 0 {
-		result, _, err := addInstanceToPlacement(ph.GeneratePlacement(), leavingInstance, false)
+		result, _, err := addInstanceToPlacement(ph.GeneratePlacement(false), leavingInstance, false)
 		return result, err
 	}
 
@@ -141,7 +141,7 @@ func (a rackAwarePlacementAlgorithm) ReplaceInstance(
 		return nil, err
 	}
 	// fill up to the target load for added instances if have not already done so
-	newPlacement := ph.GeneratePlacement()
+	newPlacement := ph.GeneratePlacement(true)
 	for _, addingInstance := range addingInstances {
 		newPlacement, addingInstance, err = removeInstanceFromPlacement(newPlacement, addingInstance.ID())
 		if err != nil {
@@ -180,7 +180,7 @@ func (a rackAwarePlacementAlgorithm) addInstance(p services.ServicePlacement, ad
 		}
 	}
 
-	return ph.GeneratePlacement(), nil
+	return ph.GeneratePlacement(false), nil
 }
 
 func (a rackAwarePlacementAlgorithm) moveLeavingShardsBack(p services.ServicePlacement, source services.PlacementInstance) services.ServicePlacement {
@@ -200,5 +200,5 @@ func (a rackAwarePlacementAlgorithm) moveLeavingShardsBack(p services.ServicePla
 		}
 	}
 
-	return ph.GeneratePlacement()
+	return ph.GeneratePlacement(false)
 }

--- a/services/placement/algo/sharded.go
+++ b/services/placement/algo/sharded.go
@@ -51,7 +51,7 @@ func (a rackAwarePlacementAlgorithm) InitialPlacement(instances []services.Place
 	if err := ph.PlaceShards(newShards(shards), nil); err != nil {
 		return nil, err
 	}
-	return ph.GeneratePlacement(false), nil
+	return ph.generatePlacement(nonEmptyOnly), nil
 }
 
 func (a rackAwarePlacementAlgorithm) AddReplica(p services.ServicePlacement) (services.ServicePlacement, error) {
@@ -64,7 +64,7 @@ func (a rackAwarePlacementAlgorithm) AddReplica(p services.ServicePlacement) (se
 	if err := ph.PlaceShards(newShards(p.Shards()), nil); err != nil {
 		return nil, err
 	}
-	return ph.GeneratePlacement(false), nil
+	return ph.generatePlacement(nonEmptyOnly), nil
 }
 
 func (a rackAwarePlacementAlgorithm) RemoveInstance(p services.ServicePlacement, instanceID string) (services.ServicePlacement, error) {
@@ -82,7 +82,7 @@ func (a rackAwarePlacementAlgorithm) RemoveInstance(p services.ServicePlacement,
 		return nil, err
 	}
 
-	result, _, err := addInstanceToPlacement(ph.GeneratePlacement(false), leavingInstance, false)
+	result, _, err := addInstanceToPlacement(ph.generatePlacement(nonEmptyOnly), leavingInstance, false)
 	return result, err
 }
 
@@ -125,7 +125,7 @@ func (a rackAwarePlacementAlgorithm) ReplaceInstance(
 	}
 
 	if loadOnInstance(leavingInstance) == 0 {
-		result, _, err := addInstanceToPlacement(ph.GeneratePlacement(false), leavingInstance, false)
+		result, _, err := addInstanceToPlacement(ph.generatePlacement(nonEmptyOnly), leavingInstance, false)
 		return result, err
 	}
 
@@ -141,7 +141,7 @@ func (a rackAwarePlacementAlgorithm) ReplaceInstance(
 		return nil, err
 	}
 	// fill up to the target load for added instances if have not already done so
-	newPlacement := ph.GeneratePlacement(true)
+	newPlacement := ph.generatePlacement(includeEmpty)
 	for _, addingInstance := range addingInstances {
 		newPlacement, addingInstance, err = removeInstanceFromPlacement(newPlacement, addingInstance.ID())
 		if err != nil {
@@ -180,7 +180,7 @@ func (a rackAwarePlacementAlgorithm) addInstance(p services.ServicePlacement, ad
 		}
 	}
 
-	return ph.GeneratePlacement(false), nil
+	return ph.generatePlacement(nonEmptyOnly), nil
 }
 
 func (a rackAwarePlacementAlgorithm) moveLeavingShardsBack(p services.ServicePlacement, source services.PlacementInstance) services.ServicePlacement {
@@ -200,5 +200,5 @@ func (a rackAwarePlacementAlgorithm) moveLeavingShardsBack(p services.ServicePla
 		}
 	}
 
-	return ph.GeneratePlacement(false)
+	return ph.generatePlacement(nonEmptyOnly)
 }

--- a/services/placement/algo/sharded_helper.go
+++ b/services/placement/algo/sharded_helper.go
@@ -30,13 +30,17 @@ import (
 	"github.com/m3db/m3cluster/shard"
 )
 
+type includeInstanceType int
+
+const (
+	includeEmpty includeInstanceType = iota
+	nonEmptyOnly
+)
+
 // PlacementHelper helps the algorithm to place shards
 type PlacementHelper interface {
 	// PlaceShards distributes shards to the instances in the helper, with aware of where are the shards coming from
 	PlaceShards(shards []shard.Shard, from services.PlacementInstance) error
-
-	// GeneratePlacement generates a placement
-	GeneratePlacement(includeEmptyInstance bool) services.ServicePlacement
 
 	// TargetLoadForInstance returns the targe load for a instance
 	TargetLoadForInstance(id string) int
@@ -52,6 +56,9 @@ type PlacementHelper interface {
 
 	// BuildInstanceHeap returns heap of instances sorted by available capacity
 	BuildInstanceHeap(instances []services.PlacementInstance, availableCapacityAscending bool) heap.Interface
+
+	// generatePlacement generates a placement
+	generatePlacement(t includeInstanceType) services.ServicePlacement
 }
 
 type placementHelper struct {
@@ -134,17 +141,19 @@ func (ph *placementHelper) BuildInstanceHeap(instances []services.PlacementInsta
 	return newHeap(instances, availableCapacityAscending, ph.targetLoad, ph.rackToWeightMap)
 }
 
-func (ph *placementHelper) GeneratePlacement(includeEmptyInstance bool) services.ServicePlacement {
+func (ph *placementHelper) generatePlacement(t includeInstanceType) services.ServicePlacement {
 	var instances []services.PlacementInstance
-	if !includeEmptyInstance {
+
+	switch t {
+	case includeEmpty:
+		instances = ph.instanceList()
+	case nonEmptyOnly:
 		instances = make([]services.PlacementInstance, 0, len(ph.instances))
 		for _, instance := range ph.instances {
 			if instance.Shards().NumShards() > 0 {
 				instances = append(instances, instance)
 			}
 		}
-	} else {
-		instances = ph.instanceList()
 	}
 
 	return placement.NewPlacement().

--- a/services/placement/algo/sharded_helper_test.go
+++ b/services/placement/algo/sharded_helper_test.go
@@ -351,6 +351,33 @@ func TestReturnInitShardToSource_SourceIsLeaving(t *testing.T) {
 	assert.Equal(t, 0, i3.Shards().NumShards())
 }
 
+func TestGeneratePlacement(t *testing.T) {
+	i1 := placement.NewInstance().SetID("i1").SetRack("r1").SetEndpoint("e1").SetWeight(1).SetShards(shard.NewShards(
+		[]shard.Shard{shard.NewShard(0).SetState(shard.Initializing).SetSourceID("i2")},
+	))
+	i2 := placement.NewInstance().SetID("i2").SetRack("r2").SetEndpoint("e2").SetWeight(1).SetShards(shard.NewShards(
+		[]shard.Shard{shard.NewShard(0).SetState(shard.Leaving)},
+	))
+	i3 := placement.NewInstance().SetID("i3").SetRack("r3").SetEndpoint("e3").SetWeight(1).SetShards(shard.NewShards(
+		[]shard.Shard{},
+	))
+
+	ph := NewPlacementHelper(
+		placement.NewPlacement().
+			SetInstances([]services.PlacementInstance{i1, i2, i3}).
+			SetReplicaFactor(1).
+			SetShards([]uint32{0}).
+			SetIsSharded(true),
+		placement.NewOptions(),
+	)
+
+	p := ph.GeneratePlacement(true)
+	assert.Equal(t, 3, p.NumInstances())
+
+	p = ph.GeneratePlacement(false)
+	assert.Equal(t, 2, p.NumInstances())
+}
+
 func TestReturnInitShardToSource_RackConflict(t *testing.T) {
 	i1 := placement.NewInstance().SetID("i1").SetRack("r1").SetEndpoint("e1").SetWeight(1).SetShards(shard.NewShards(
 		[]shard.Shard{shard.NewShard(0).SetState(shard.Initializing).SetSourceID("i2")},

--- a/services/placement/algo/sharded_helper_test.go
+++ b/services/placement/algo/sharded_helper_test.go
@@ -371,10 +371,10 @@ func TestGeneratePlacement(t *testing.T) {
 		placement.NewOptions(),
 	)
 
-	p := ph.GeneratePlacement(true)
+	p := ph.generatePlacement(includeEmpty)
 	assert.Equal(t, 3, p.NumInstances())
 
-	p = ph.GeneratePlacement(false)
+	p = ph.generatePlacement(nonEmptyOnly)
 	assert.Equal(t, 2, p.NumInstances())
 }
 


### PR DESCRIPTION
Previously when backing out from a replace, the empty instance in the
placement is not being cleaned up, this diff fixes that.

@xichen2020 @robskillington 