### PR TITLE
Call Get() after service discovery watch timed-out for initial value

### DIFF
--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -143,7 +143,8 @@ func (c *csclient) kvGen(kvOpts etcdKV.Options) sdClient.KVGen {
 			}
 
 			return etcdKV.NewStore(
-				cli,
+				cli.KV,
+				cli.Watcher,
 				kvOpts.SetCacheFilePath(cacheFileForZone(c.opts.CacheDir(), kvOpts.ApplyPrefix(c.opts.AppID()), zone)),
 			)
 		},

--- a/kv/mem/store.go
+++ b/kv/mem/store.go
@@ -60,6 +60,7 @@ type value struct {
 
 func (v value) Version() int                      { return v.version }
 func (v value) Unmarshal(msg proto.Message) error { return proto.Unmarshal(v.data, msg) }
+func (v value) IsNewer(other kv.Value) bool       { return v.version > other.Version() }
 
 type store struct {
 	sync.RWMutex

--- a/kv/mem/store_test.go
+++ b/kv/mem/store_test.go
@@ -29,6 +29,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValue(t *testing.T) {
+	v1 := NewValue(1, &kvtest.Foo{
+		Msg: "1",
+	})
+
+	v2 := NewValue(2, &kvtest.Foo{
+		Msg: "2",
+	})
+
+	require.True(t, v2.IsNewer(v1))
+}
+
 func TestStore(t *testing.T) {
 	s := NewStore()
 

--- a/kv/types.go
+++ b/kv/types.go
@@ -47,6 +47,9 @@ type Value interface {
 
 	// Version returns the current version of the value
 	Version() int
+
+	// IsNewer returns if this Value is newer than the other Value
+	IsNewer(other Value) bool
 }
 
 // ValueWatch provides updates to a Value

--- a/services/client/services.go
+++ b/services/client/services.go
@@ -249,12 +249,17 @@ func (c *client) Watch(sid services.ServiceID, opts services.QueryOptions) (xwat
 	}
 
 	// prepare the watch of placement outside of lock
-	placementWatch, err := initPlacementWatch(kvm.kv, sid, c.opts.InitTimeout())
+	placementWatch, err := kvm.kv.Watch(placementKey(sid))
 	if err != nil {
 		return nil, err
 	}
 
-	initService, err := getServiceFromValue(placementWatch.Get(), sid)
+	initValue, err := waitForInitValue(kvm.kv, placementWatch, sid, c.opts.InitTimeout())
+	if err != nil {
+		return nil, fmt.Errorf("could not get init value within timeout, err: %s", err)
+	}
+
+	initService, err := getServiceFromValue(initValue, sid)
 	if err != nil {
 		placementWatch.Close()
 		return nil, err
@@ -285,10 +290,10 @@ func (c *client) Watch(sid services.ServiceID, opts services.QueryOptions) (xwat
 			return nil, err
 		}
 		watchable.Update(filterInstancesWithWatch(initService, heartbeatWatch))
-		go c.watchPlacementAndHeartbeat(watchable, placementWatch, heartbeatWatch, sid, initService, sdm.serviceUnmalshalErr)
+		go c.watchPlacementAndHeartbeat(watchable, placementWatch, heartbeatWatch, initValue, sid, initService, sdm.serviceUnmalshalErr)
 	} else {
 		watchable.Update(initService)
-		go c.watchPlacement(watchable, placementWatch, sid, sdm.serviceUnmalshalErr)
+		go c.watchPlacement(watchable, placementWatch, initValue, sid, sdm.serviceUnmalshalErr)
 	}
 
 	kvm.serviceWatchables[key] = watchable
@@ -355,6 +360,7 @@ func (c *client) getKVManager(zone string) (*kvManager, error) {
 func (c *client) watchPlacement(
 	w xwatch.Watchable,
 	vw kv.ValueWatch,
+	initValue kv.Value,
 	sid services.ServiceID,
 	errCounter tally.Counter,
 ) {
@@ -365,7 +371,15 @@ func (c *client) watchPlacement(
 			if value == nil {
 				// NB(cw) this can only happen when the placement has been deleted
 				// it is safer to let the user keep using the old topology
-				c.logger.Infof("received placement update with nil value")
+				c.logger.Info("received placement update with nil value")
+				continue
+			}
+
+			if initValue != nil && !value.IsNewer(initValue) {
+				// NB(cw) this can only happen when the init wait called a Get() itself
+				// so the init value did not come from the watch, when the watch gets created
+				// the first update from it may from the same version.
+				c.logger.Info("received placement update on old version, skip")
 				continue
 			}
 
@@ -386,6 +400,7 @@ func (c *client) watchPlacementAndHeartbeat(
 	w xwatch.Watchable,
 	vw kv.ValueWatch,
 	heartbeatWatch xwatch.Watch,
+	initValue kv.Value,
 	sid services.ServiceID,
 	service services.Service,
 	errCounter tally.Counter,
@@ -397,7 +412,15 @@ func (c *client) watchPlacementAndHeartbeat(
 			if value == nil {
 				// NB(cw) this can only happen when the placement has been deleted
 				// it is safer to let the user keep using the old topology
-				c.logger.Infof("received placement update with nil value")
+				c.logger.Info("received placement update with nil value")
+				continue
+			}
+
+			if initValue != nil && !value.IsNewer(initValue) {
+				// NB(cw) this can only happen when the init wait called a Get() itself
+				// so the init value did not come from the watch, when the watch gets created
+				// the first update from it may from the same version.
+				c.logger.Info("received placement update on old version, skip")
 				continue
 			}
 
@@ -475,20 +498,13 @@ func getServiceFromValue(value kv.Value, sid services.ServiceID) (services.Servi
 	return serviceFromProto(placement, sid)
 }
 
-func initPlacementWatch(kv kv.Store, sid services.ServiceID, timeoutDur time.Duration) (kv.ValueWatch, error) {
-	valueWatch, err := kv.Watch(placementKey(sid))
-	if err != nil {
-		valueWatch.Close()
-		return nil, err
+func waitForInitValue(kvStore kv.Store, w kv.ValueWatch, sid services.ServiceID, timeoutDur time.Duration) (kv.Value, error) {
+	err := wait(w, timeoutDur)
+	if err == nil {
+		return w.Get(), nil
 	}
 
-	err = wait(valueWatch, timeoutDur)
-	if err != nil {
-		valueWatch.Close()
-		return nil, err
-	}
-
-	return valueWatch, nil
+	return kvStore.Get(placementKey(sid))
 }
 
 func wait(vw kv.ValueWatch, timeout time.Duration) error {


### PR DESCRIPTION
So that the config for service discovery watch timeout will always try a Get() and is independent
from the config for watch creation timeout and/or get request timeouts

@xichen2020 @robskillington 