### PR TITLE
[placement] Options: add ValidZone + SetValidZone

### DIFF
--- a/services/placement/options.go
+++ b/services/placement/options.go
@@ -65,6 +65,7 @@ type options struct {
 	sharded             bool
 	dryrun              bool
 	iopts               instrument.Options
+	validZone           string
 }
 
 func (o options) LooseRackCheck() bool {
@@ -109,5 +110,14 @@ func (o options) InstrumentOptions() instrument.Options {
 
 func (o options) SetInstrumentOptions(iopts instrument.Options) services.PlacementOptions {
 	o.iopts = iopts
+	return o
+}
+
+func (o options) ValidZone() string {
+	return o.validZone
+}
+
+func (o options) SetValidZone(z string) services.PlacementOptions {
+	o.validZone = z
 	return o
 }

--- a/services/placement/service/placementservice.go
+++ b/services/placement/service/placementservice.go
@@ -439,12 +439,16 @@ func filterZones(
 	candidates []services.PlacementInstance,
 	opts services.PlacementOptions,
 ) []services.PlacementInstance {
+	if len(candidates) == 0 {
+		return []services.PlacementInstance{}
+	}
+
 	var validZone string
-	for _, instance := range p.Instances() {
-		if validZone == "" {
-			validZone = instance.Zone()
-			break
-		}
+	if opts != nil {
+		validZone = opts.ValidZone()
+	}
+	if validZone == "" && len(p.Instances()) > 0 {
+		validZone = p.Instances()[0].Zone()
 	}
 
 	validInstances := make([]services.PlacementInstance, 0, len(candidates))

--- a/services/placement/service/placementservice_test.go
+++ b/services/placement/service/placementservice_test.go
@@ -932,6 +932,57 @@ func TestRackLenSort(t *testing.T) {
 	}
 }
 
+func TestFilterZones(t *testing.T) {
+	i1 := placement.NewInstance().SetID("i1").SetZone("z1")
+	i2 := placement.NewInstance().SetID("i2").SetZone("z1")
+	i3 := placement.NewInstance().SetID("i2").SetZone("z1")
+	i4 := placement.NewInstance().SetID("i3").SetZone("z2")
+
+	_, _ = i2, i3
+
+	tests := map[*struct {
+		p          services.ServicePlacement
+		candidates []services.PlacementInstance
+		opts       services.PlacementOptions
+	}][]services.PlacementInstance{
+		{
+			p:          placement.NewPlacement().SetInstances([]services.PlacementInstance{i1}),
+			candidates: []services.PlacementInstance{},
+			opts:       nil,
+		}: []services.PlacementInstance{},
+		{
+			p:          placement.NewPlacement().SetInstances([]services.PlacementInstance{i1}),
+			candidates: []services.PlacementInstance{i2},
+			opts:       nil,
+		}: []services.PlacementInstance{i2},
+		{
+			p:          placement.NewPlacement().SetInstances([]services.PlacementInstance{i1}),
+			candidates: []services.PlacementInstance{i2, i4},
+			opts:       nil,
+		}: []services.PlacementInstance{i2},
+		{
+			p:          placement.NewPlacement().SetInstances([]services.PlacementInstance{i1}),
+			candidates: []services.PlacementInstance{i2, i3},
+			opts:       nil,
+		}: []services.PlacementInstance{i2, i3},
+		{
+			p:          placement.NewPlacement(),
+			candidates: []services.PlacementInstance{i2},
+			opts:       nil,
+		}: []services.PlacementInstance{},
+		{
+			p:          placement.NewPlacement(),
+			candidates: []services.PlacementInstance{i2},
+			opts:       placement.NewOptions().SetValidZone("z1"),
+		}: []services.PlacementInstance{i2},
+	}
+
+	for args, exp := range tests {
+		res := filterZones(args.p, args.candidates, args.opts)
+		assert.Equal(t, exp, res)
+	}
+}
+
 type errorAlgorithm struct{}
 
 func (errorAlgorithm) InitialPlacement(instances []services.PlacementInstance, ids []uint32) (services.ServicePlacement, error) {

--- a/services/types.go
+++ b/services/types.go
@@ -229,6 +229,17 @@ type PlacementOptions interface {
 	// InstrumentOptions is the options for instrument
 	InstrumentOptions() instrument.Options
 	SetInstrumentOptions(iopts instrument.Options) PlacementOptions
+
+	// ValidZone returns the zone that added instances must be in in order
+	// to be added to a placement.
+	ValidZone() string
+
+	// SetValidZone sets the zone that added instances must be in in order to
+	// be added to a placement. By default the valid zone will be the zone of
+	// instances already in a placement, however if a placement is empty then
+	// it is necessary to specify the valid zone when adding the first
+	// instance.
+	SetValidZone(z string) PlacementOptions
 }
 
 // ServicePlacement describes how instances are placed in a service


### PR DESCRIPTION
When adding instances to a placement we check that the candidates have
the same zone as those in the placement. When a placement is empty we
need to explicitly set the zone to be considered valid.