### PR TITLE
Add Set() to the Storage interface

### DIFF
--- a/services/client/storage.go
+++ b/services/client/storage.go
@@ -39,6 +39,22 @@ func newPlacementStorage(opts Options) (placement.Storage, error) {
 	}, nil
 }
 
+func (s *client) Set(sid services.ServiceID, p services.ServicePlacement) error {
+	if err := validateServiceID(sid); err != nil {
+		return err
+	}
+	placementProto, err := util.PlacementToProto(p)
+	if err != nil {
+		return err
+	}
+	kvm, err := s.getKVManager(sid.Zone())
+	if err != nil {
+		return err
+	}
+	_, err = kvm.kv.Set(placementKey(sid), &placementProto)
+	return err
+}
+
 func (s *client) CheckAndSet(sid services.ServiceID, p services.ServicePlacement, version int) error {
 	if err := validateServiceID(sid); err != nil {
 		return err

--- a/services/placement/service/placementservice.go
+++ b/services/placement/service/placementservice.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/m3db/m3cluster/kv"
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3cluster/services/placement"
 	"github.com/m3db/m3cluster/services/placement/algo"
@@ -294,16 +293,7 @@ func (ps placementService) SetPlacement(p services.ServicePlacement) error {
 		return nil
 	}
 
-	_, v, err := ps.ss.Placement(ps.service)
-	if err == kv.ErrNotFound {
-		return ps.ss.SetIfNotExist(ps.service, p)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return ps.ss.CheckAndSet(ps.service, p, v)
+	return ps.ss.Set(ps.service, p)
 }
 
 func (ps placementService) Delete() error {

--- a/services/placement/service/placementservice_test.go
+++ b/services/placement/service/placementservice_test.go
@@ -1017,6 +1017,16 @@ func NewMockStorage() placement.Storage {
 	return &mockStorage{m: map[string]services.ServicePlacement{}}
 }
 
+func (ms *mockStorage) Set(service services.ServiceID, p services.ServicePlacement) error {
+	ms.Lock()
+	defer ms.Unlock()
+
+	ms.m[service.Name()] = p
+	ms.version++
+
+	return nil
+}
+
 func (ms *mockStorage) CheckAndSet(service services.ServiceID, p services.ServicePlacement, v int) error {
 	ms.Lock()
 	defer ms.Unlock()
@@ -1052,6 +1062,7 @@ func (ms *mockStorage) Delete(service services.ServiceID) error {
 	}
 
 	delete(ms.m, service.Name())
+	ms.version = 0
 	return nil
 }
 

--- a/services/placement/types.go
+++ b/services/placement/types.go
@@ -48,7 +48,11 @@ type DeploymentPlanner interface {
 
 // Storage provides read and write access to service placement
 type Storage interface {
-	// CheckAndSet writes a placement for a service
+	// Set writes a placement for a service
+	Set(service services.ServiceID, p services.ServicePlacement) error
+
+	// CheckAndSet writes a placement for a service if the current version
+	// matches the expected version
 	CheckAndSet(service services.ServiceID, p services.ServicePlacement, version int) error
 
 	// SetIfNotExist writes a placement for a service


### PR DESCRIPTION
cc @cw9 @robskillington 

This PR adds `Set` to the storage interface so we can write out new placements without reading from the store first. 