### PR TITLE
Add runtime value interface to m3cluster

### DIFF
--- a/kv/types.go
+++ b/kv/types.go
@@ -26,6 +26,11 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
+const (
+	// UninitializedVersion is the version of an uninitialized kv value.
+	UninitializedVersion = 0
+)
+
 var (
 	// ErrVersionMismatch is returned when attempting a CheckAndSet and the
 	// key is not at the provided version

--- a/kv/util/runtime/options.go
+++ b/kv/util/runtime/options.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package runtime
+
+import (
+	"time"
+
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3cluster/kv/mem"
+	"github.com/m3db/m3x/instrument"
+)
+
+const (
+	defaultInitWatchTimeout = 10 * time.Second
+)
+
+// Options provide a set of value options.
+type Options interface {
+	// SetInstrumentOptions sets the instrument options.
+	SetInstrumentOptions(value instrument.Options) Options
+
+	// InstrumentOptions returns the instrument options.
+	InstrumentOptions() instrument.Options
+
+	// SetInitWatchTimeout sets the initial watch timeout.
+	SetInitWatchTimeout(value time.Duration) Options
+
+	// InitWatchTimeout returns the initial watch timeout.
+	InitWatchTimeout() time.Duration
+
+	// SetKVStore sets the kv store.
+	SetKVStore(value kv.Store) Options
+
+	// KVStore returns the kv store.
+	KVStore() kv.Store
+
+	// SetUnmarshalFn sets the unmarshal function.
+	SetUnmarshalFn(value UnmarshalFn) Options
+
+	// UnmarshalFn returns the unmarshal function.
+	UnmarshalFn() UnmarshalFn
+
+	// SetProcessFn sets the process function.
+	SetProcessFn(value ProcessFn) Options
+
+	// ProcessFn returns the process function.
+	ProcessFn() ProcessFn
+}
+
+type options struct {
+	instrumentOpts   instrument.Options
+	initWatchTimeout time.Duration
+	kvStore          kv.Store
+	unmarshalFn      UnmarshalFn
+	processFn        ProcessFn
+}
+
+// NewOptions creates a new set of options.
+func NewOptions() Options {
+	return &options{
+		instrumentOpts:   instrument.NewOptions(),
+		initWatchTimeout: defaultInitWatchTimeout,
+		kvStore:          mem.NewStore(),
+	}
+}
+
+func (o *options) SetInstrumentOptions(value instrument.Options) Options {
+	opts := *o
+	opts.instrumentOpts = value
+	return &opts
+}
+
+func (o *options) InstrumentOptions() instrument.Options {
+	return o.instrumentOpts
+}
+
+func (o *options) SetInitWatchTimeout(value time.Duration) Options {
+	opts := *o
+	opts.initWatchTimeout = value
+	return &opts
+}
+
+func (o *options) InitWatchTimeout() time.Duration {
+	return o.initWatchTimeout
+}
+
+func (o *options) SetKVStore(value kv.Store) Options {
+	opts := *o
+	opts.kvStore = value
+	return &opts
+}
+
+func (o *options) KVStore() kv.Store {
+	return o.kvStore
+}
+
+func (o *options) SetUnmarshalFn(value UnmarshalFn) Options {
+	opts := *o
+	opts.unmarshalFn = value
+	return &opts
+}
+
+func (o *options) UnmarshalFn() UnmarshalFn {
+	return o.unmarshalFn
+}
+
+func (o *options) SetProcessFn(value ProcessFn) Options {
+	opts := *o
+	opts.processFn = value
+	return &opts
+}
+
+func (o *options) ProcessFn() ProcessFn {
+	return o.processFn
+}

--- a/kv/util/runtime/options.go
+++ b/kv/util/runtime/options.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/m3db/m3cluster/kv"
-	"github.com/m3db/m3cluster/kv/mem"
 	"github.com/m3db/m3x/instrument"
 )
 
@@ -78,7 +77,6 @@ func NewOptions() Options {
 	return &options{
 		instrumentOpts:   instrument.NewOptions(),
 		initWatchTimeout: defaultInitWatchTimeout,
-		kvStore:          mem.NewStore(),
 	}
 }
 

--- a/kv/util/runtime/value.go
+++ b/kv/util/runtime/value.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3x/log"
+)
+
+const (
+	// DefaultVersion is the default version of an uninitialized kv value.
+	DefaultVersion = 0
+)
+
+var (
+	errInitWatchTimeout = errors.New("init watch timeout")
+	errNilValue         = errors.New("nil kv value")
+)
+
+// Value is a value that can be updated during runtime.
+type Value interface {
+	// Key is the key associated with value.
+	Key() string
+
+	// Watch starts watching for value updates.
+	Watch() error
+
+	// Unwatch stops watching for value updates.
+	Unwatch()
+}
+
+// UnmarshalFn unmarshals a kv value and extracts its payload.
+type UnmarshalFn func(value kv.Value) (interface{}, error)
+
+// ProcessFn processes a value.
+type ProcessFn func(value interface{}) error
+
+// updateWithLockFn updates a value while holding a lock.
+type updateWithLockFn func(value kv.Value) error
+
+type valueStatus int
+
+const (
+	valueNotWatching valueStatus = iota
+	valueWatching
+)
+
+type value struct {
+	sync.RWMutex
+
+	key              string
+	store            kv.Store
+	opts             Options
+	log              xlog.Logger
+	unmarshalFn      UnmarshalFn
+	processFn        ProcessFn
+	updateWithLockFn updateWithLockFn
+
+	status  valueStatus
+	watch   kv.ValueWatch
+	version int
+}
+
+// NewValue creates a new value.
+func NewValue(
+	key string,
+	opts Options,
+) Value {
+	v := &value{
+		key:         key,
+		opts:        opts,
+		store:       opts.KVStore(),
+		log:         opts.InstrumentOptions().Logger(),
+		unmarshalFn: opts.UnmarshalFn(),
+		processFn:   opts.ProcessFn(),
+		version:     DefaultVersion,
+	}
+	v.updateWithLockFn = v.updateWithLock
+	return v
+}
+
+func (v *value) Key() string { return v.key }
+
+func (v *value) Watch() error {
+	v.Lock()
+	defer v.Unlock()
+
+	if v.status == valueWatching {
+		return nil
+	}
+	watch, err := v.store.Watch(v.key)
+	if err != nil {
+		return CreateWatchError{innerError: err}
+	}
+	v.status = valueWatching
+	v.watch = watch
+
+	select {
+	case <-watch.C():
+	case <-time.After(v.opts.InitWatchTimeout()):
+		err = errInitWatchTimeout
+	}
+
+	if err == nil {
+		err = v.updateWithLockFn(watch.Get())
+	}
+
+	// NB(xichen): we want to start watching updates even though
+	// we may fail to initialize the value temporarily (e.g., during
+	// a network partition) so the value will be updated when the
+	// error condition is resolved.
+	go v.watchUpdates(v.watch)
+	if err != nil {
+		return InitValueError{innerError: err}
+	}
+	return nil
+}
+
+func (v *value) Unwatch() {
+	v.Lock()
+	defer v.Unlock()
+
+	// If status is nil, it means we are not watching.
+	if v.status == valueNotWatching {
+		return
+	}
+	v.watch.Close()
+	v.status = valueNotWatching
+	v.watch = nil
+}
+
+func (v *value) watchUpdates(watch kv.ValueWatch) {
+	for range watch.C() {
+		v.Lock()
+		// If we are not watching, or we are watching with a different
+		// watch because we stopped the current watch and started a new
+		// one, return immediately.
+		if v.status != valueWatching || v.watch != watch {
+			v.Unlock()
+			return
+		}
+		if err := v.updateWithLockFn(watch.Get()); err != nil {
+			v.log.Errorf("error updating value: %v", err)
+		}
+		v.Unlock()
+	}
+}
+
+func (v *value) updateWithLock(update kv.Value) error {
+	if update == nil {
+		return errNilValue
+	}
+	newVersion := update.Version()
+	if newVersion <= v.version {
+		return nil
+	}
+	latest, err := v.unmarshalFn(update)
+	if err != nil {
+		err = fmt.Errorf("error unmarshalling value for version %d: %v", newVersion, err)
+		return err
+	}
+	if err := v.processFn(latest); err != nil {
+		return err
+	}
+	v.version = newVersion
+	return nil
+}
+
+// CreateWatchError is returned when encountering an error creating a watch.
+type CreateWatchError struct {
+	innerError error
+}
+
+func (e CreateWatchError) Error() string {
+	return fmt.Sprintf("create watch error:%v", e.innerError)
+}
+
+// InitValueError is returned when encountering an error when initializing a value.
+type InitValueError struct {
+	innerError error
+}
+
+func (e InitValueError) Error() string {
+	return fmt.Sprintf("initializing value error:%v", e.innerError)
+}

--- a/kv/util/runtime/value.go
+++ b/kv/util/runtime/value.go
@@ -30,11 +30,6 @@ import (
 	"github.com/m3db/m3x/log"
 )
 
-const (
-	// DefaultVersion is the default version of an uninitialized kv value.
-	DefaultVersion = 0
-)
-
 var (
 	errInitWatchTimeout = errors.New("init watch timeout")
 	errNilValue         = errors.New("nil kv value")
@@ -96,7 +91,7 @@ func NewValue(
 		log:         opts.InstrumentOptions().Logger(),
 		unmarshalFn: opts.UnmarshalFn(),
 		processFn:   opts.ProcessFn(),
-		version:     DefaultVersion,
+		version:     kv.UninitializedVersion,
 	}
 	v.updateWithLockFn = v.updateWithLock
 	return v

--- a/kv/util/runtime/value_test.go
+++ b/kv/util/runtime/value_test.go
@@ -1,0 +1,306 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package runtime
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/m3db/m3cluster/generated/proto/commonpb"
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3cluster/kv/mem"
+	"github.com/m3db/m3x/instrument"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testValueKey = "testValue"
+)
+
+func TestValueWatchAlreadyWatching(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, rv := testValueWithMockStore(ctrl)
+	rv.status = valueWatching
+	require.NoError(t, rv.Watch())
+}
+
+func TestValueWatchCreateWatchError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store, rv := testValueWithMockStore(ctrl)
+	errWatch := errors.New("error creating watch")
+	store.EXPECT().Watch(rv.key).Return(nil, errWatch)
+
+	require.Equal(t, CreateWatchError{innerError: errWatch}, rv.Watch())
+	require.Equal(t, valueNotWatching, rv.status)
+
+	rv.Unwatch()
+	require.Equal(t, valueNotWatching, rv.status)
+}
+
+func TestValueWatchWatchTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store, rv := testValueWithMockStore(ctrl)
+	notifyCh := make(chan struct{})
+	mockWatch := kv.NewMockValueWatch(ctrl)
+	mockWatch.EXPECT().C().Return(notifyCh).MinTimes(1)
+	mockWatch.EXPECT().Close().Do(func() { close(notifyCh) })
+	store.EXPECT().Watch(rv.key).Return(mockWatch, nil)
+
+	require.Equal(t, InitValueError{innerError: errInitWatchTimeout}, rv.Watch())
+	require.Equal(t, valueWatching, rv.status)
+
+	rv.Unwatch()
+	require.Equal(t, valueNotWatching, rv.status)
+}
+
+func TestValueWatchUpdateError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store, rv := testValueWithMockStore(ctrl)
+	errUpdate := errors.New("error updating")
+	rv.updateWithLockFn = func(kv.Value) error { return errUpdate }
+	notifyCh := make(chan struct{}, 1)
+	notifyCh <- struct{}{}
+	mockWatch := kv.NewMockValueWatch(ctrl)
+	mockWatch.EXPECT().C().Return(notifyCh).MinTimes(1)
+	mockWatch.EXPECT().Get().Return(nil)
+	mockWatch.EXPECT().Close().Do(func() { close(notifyCh) })
+	store.EXPECT().Watch(rv.key).Return(mockWatch, nil)
+
+	require.Equal(t, InitValueError{innerError: errUpdate}, rv.Watch())
+	require.Equal(t, valueWatching, rv.status)
+
+	rv.Unwatch()
+	require.Equal(t, valueNotWatching, rv.status)
+}
+
+func TestValueWatchSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store, rv := testValueWithMockStore(ctrl)
+	rv.updateWithLockFn = func(kv.Value) error { return nil }
+	notifyCh := make(chan struct{}, 1)
+	notifyCh <- struct{}{}
+	mockWatch := kv.NewMockValueWatch(ctrl)
+	mockWatch.EXPECT().C().Return(notifyCh).MinTimes(1)
+	mockWatch.EXPECT().Get().Return(nil)
+	mockWatch.EXPECT().Close().Do(func() { close(notifyCh) })
+	store.EXPECT().Watch(rv.key).Return(mockWatch, nil)
+
+	require.NoError(t, rv.Watch())
+	require.Equal(t, valueWatching, rv.status)
+
+	rv.Unwatch()
+	require.Equal(t, valueNotWatching, rv.status)
+}
+
+func TestValueUnwatchNotWatching(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, rv := testValueWithMockStore(ctrl)
+	rv.status = valueNotWatching
+	rv.Unwatch()
+	require.Equal(t, valueNotWatching, rv.status)
+}
+
+func TestValueWatchUnWatchMultipleTimes(t *testing.T) {
+	store, rv := testValueWithMemStore()
+	rv.updateWithLockFn = func(kv.Value) error { return nil }
+	_, err := store.SetIfNotExists(testValueKey, &commonpb.BoolProto{})
+	require.NoError(t, err)
+
+	iter := 10
+	for i := 0; i < iter; i++ {
+		require.NoError(t, rv.Watch())
+		rv.Unwatch()
+	}
+}
+
+func TestValueWatchUpdatesError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, rv := testValueWithMockStore(ctrl)
+	errUpdate := errors.New("error updating")
+	rv.updateWithLockFn = func(kv.Value) error { return errUpdate }
+	ch := make(chan struct{})
+	watch := kv.NewMockValueWatch(ctrl)
+	watch.EXPECT().C().Return(ch).AnyTimes()
+	watch.EXPECT().Get().Return(nil)
+	watch.EXPECT().Close().Do(func() { close(ch) })
+	rv.watch = watch
+	rv.status = valueWatching
+	go rv.watchUpdates(watch)
+
+	ch <- struct{}{}
+	rv.Unwatch()
+	require.Equal(t, valueNotWatching, rv.status)
+}
+
+func TestValueWatchValueUnwatched(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, rv := testValueWithMockStore(ctrl)
+	var updated int32
+	rv.updateWithLockFn = func(kv.Value) error { atomic.AddInt32(&updated, 1); return nil }
+	ch := make(chan struct{})
+	watch := kv.NewMockValueWatch(ctrl)
+	watch.EXPECT().C().Return(ch).AnyTimes()
+	watch.EXPECT().Get().Return(nil).AnyTimes()
+	watch.EXPECT().Close().Do(func() { close(ch) }).AnyTimes()
+	rv.watch = watch
+	rv.status = valueNotWatching
+	go rv.watchUpdates(watch)
+
+	ch <- struct{}{}
+	// Given the update goroutine a chance to run.
+	time.Sleep(100 * time.Millisecond)
+	close(ch)
+	require.Equal(t, int32(0), atomic.LoadInt32(&updated))
+}
+
+func TestValueWatchValueDifferentWatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, rv := testValueWithMockStore(ctrl)
+	var updated int32
+	rv.updateWithLockFn = func(kv.Value) error { atomic.AddInt32(&updated, 1); return nil }
+	ch := make(chan struct{})
+	watch := kv.NewMockValueWatch(ctrl)
+	watch.EXPECT().C().Return(ch).AnyTimes()
+	watch.EXPECT().Get().Return(nil).AnyTimes()
+	watch.EXPECT().Close().Do(func() { close(ch) }).AnyTimes()
+	rv.watch = kv.NewMockValueWatch(ctrl)
+	rv.status = valueWatching
+	go rv.watchUpdates(watch)
+
+	ch <- struct{}{}
+	// Given the update goroutine a chance to run.
+	time.Sleep(100 * time.Millisecond)
+	close(ch)
+	require.Equal(t, int32(0), atomic.LoadInt32(&updated))
+}
+
+func TestValueUpdateNilValueError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, rv := testValueWithMockStore(ctrl)
+	require.Equal(t, errNilValue, rv.updateWithLockFn(nil))
+}
+
+func TestValueUpdateUnmarshalError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, rv := testValueWithMockStore(ctrl)
+	errUnmarshal := errors.New("error unmarshaling")
+	rv.unmarshalFn = func(v kv.Value) (interface{}, error) { return nil, errUnmarshal }
+
+	require.Error(t, rv.updateWithLockFn(mockValue{version: 3}))
+}
+
+func TestValueUpdateProcessError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, rv := testValueWithMockStore(ctrl)
+	errProcess := errors.New("error processing")
+	rv.unmarshalFn = func(v kv.Value) (interface{}, error) { return nil, nil }
+	rv.processFn = func(v interface{}) error { return errProcess }
+
+	require.Error(t, rv.updateWithLockFn(mockValue{version: 3}))
+}
+
+func TestValueUpdateSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var outputs []mockValue
+	_, rv := testValueWithMockStore(ctrl)
+	rv.unmarshalFn = func(v kv.Value) (interface{}, error) { return v, nil }
+	rv.processFn = func(v interface{}) error {
+		outputs = append(outputs, v.(mockValue))
+		return nil
+	}
+
+	input := mockValue{version: 3}
+	require.NoError(t, rv.updateWithLock(input))
+	require.Equal(t, []mockValue{input}, outputs)
+	require.Equal(t, 3, rv.version)
+}
+
+func TestValueUpdateStaleUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, rv := testValueWithMockStore(ctrl)
+	rv.version = 3
+	rv.unmarshalFn = func(v kv.Value) (interface{}, error) { return v, nil }
+
+	require.NoError(t, rv.updateWithLock(mockValue{version: 2}))
+	require.Equal(t, 3, rv.version)
+}
+
+type mockValue struct {
+	version int
+}
+
+func (v mockValue) Unmarshal(proto.Message) error { return errors.New("unimplemented") }
+func (v mockValue) Version() int                  { return v.version }
+func (v mockValue) IsNewer(other kv.Value) bool   { return v.version > other.Version() }
+
+func testValueOptions(store kv.Store) Options {
+	return NewOptions().
+		SetInstrumentOptions(instrument.NewOptions()).
+		SetInitWatchTimeout(100 * time.Millisecond).
+		SetKVStore(store).
+		SetUnmarshalFn(nil).
+		SetProcessFn(nil)
+}
+
+func testValueWithMockStore(ctrl *gomock.Controller) (*kv.MockStore, *value) {
+	store := kv.NewMockStore(ctrl)
+	opts := testValueOptions(store)
+	return store, NewValue(testValueKey, opts).(*value)
+}
+
+func testValueWithMemStore() (kv.Store, *value) {
+	store := mem.NewStore()
+	opts := testValueOptions(store)
+	return store, NewValue(testValueKey, opts).(*value)
+}


### PR DESCRIPTION
cc @cw9 @jeromefroe @martin-mao 

This PR adds the runtime value interface to m3cluster, which provides the ability to watch / unwatch updates and process the updates using the configurable unmarshalling function and processing function.