### PR TITLE
[client/etcd] Refactor clientinterface to require a namespace

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -32,8 +32,8 @@ type Client interface {
 	Services() (services.Services, error)
 
 	// KV returns access to the distributed configuration store
-	KV() (kv.Store, error)
+	KV(namespace string) (kv.Store, error)
 
 	// Txn returns access to the transaction store
-	Txn() (kv.TxnStore, error)
+	Txn(namespace string) (kv.TxnStore, error)
 }

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -55,6 +55,8 @@ func TestETCDClientGen(t *testing.T) {
 }
 
 func TestKVAndHeartbeatServiceSharingETCDClient(t *testing.T) {
+	namespace := "kv"
+
 	sid := services.NewServiceID().SetName("s1")
 
 	cs, err := NewConfigServiceClient(testOptions().SetZone("zone1"))
@@ -62,7 +64,7 @@ func TestKVAndHeartbeatServiceSharingETCDClient(t *testing.T) {
 
 	c := cs.(*csclient)
 
-	_, err = c.KV()
+	_, err = c.KV(namespace)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(c.clis))
 
@@ -80,12 +82,14 @@ func TestKVAndHeartbeatServiceSharingETCDClient(t *testing.T) {
 }
 
 func TestClient(t *testing.T) {
+	namespace := "kv"
+
 	_, err := NewConfigServiceClient(NewOptions())
 	assert.Error(t, err)
 
 	cs, err := NewConfigServiceClient(testOptions())
 	assert.NoError(t, err)
-	_, err = cs.KV()
+	_, err = cs.KV(namespace)
 	assert.Error(t, err)
 
 	cs, err = NewConfigServiceClient(testOptions().SetZone("zone1"))
@@ -95,14 +99,14 @@ func TestClient(t *testing.T) {
 	defer closer()
 	c.newFn = fn
 
-	txn, err := c.Txn()
+	txn, err := c.Txn(namespace)
 	assert.NoError(t, err)
 
-	kv1, err := c.KV()
+	kv1, err := c.KV(namespace)
 	assert.NoError(t, err)
 	assert.Equal(t, kv1, txn)
 
-	kv2, err := c.KV()
+	kv2, err := c.KV(namespace)
 	assert.NoError(t, err)
 	assert.Equal(t, kv1, kv2)
 	// KV store will create an etcd cli for local zone only
@@ -152,9 +156,9 @@ func TestCacheFileForZone(t *testing.T) {
 	assert.Equal(t, "/dir/a_b-c_d.json", cacheFileForZone("/dir", "a/b", "c/d"))
 }
 
-func TestPrefix(t *testing.T) {
-	assert.Equal(t, "_kv/test/", prefix("test"))
-	assert.Equal(t, "_kv/", prefix(""))
+func TestFullPrefix(t *testing.T) {
+	assert.Equal(t, "/kv/test/", fullPrefix("kv", "test"))
+	assert.Equal(t, "/kv/", fullPrefix("kv", ""))
 }
 
 func testOptions() Options {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: d9cb6ee29dac603de41eb9300dcf470b753c369d325f2118f5f954bbd66dc76a
-updated: 2017-04-17T11:58:28.32863138-04:00
+updated: 2017-04-26T18:20:35.913933005-04:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -134,7 +134,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
+  version: 9e0844febd9e2856f839c9cb974fbd676d1755a8
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg


### PR DESCRIPTION
@cw9 @xichen2020 @schallert This PR refactors the `Client` interface to require a namespace when calling `KV` and `Txn`. This is so we can easily support different namespaces moving forward, e.g. `/kv` or `/r2`, that reside in the same etcd cluster per our discussions earlier.