### PR TITLE
Allow user to specify namespace in KV

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -26,22 +26,22 @@ import (
 )
 
 // Client is the base interface into the cluster management system, providing
-// access to cluster services
+// access to cluster services.
 type Client interface {
-	// Services returns access to the set of services
+	// Services returns access to the set of services.
 	Services() (services.Services, error)
 
-	// KV returns access to the distributed configuration store
-	// To be deprecated
+	// KV returns access to the distributed configuration store.
+	// To be deprecated.
 	KV() (kv.Store, error)
 
-	// Txn returns access to the transaction store
-	// To be deprecated
+	// Txn returns access to the transaction store.
+	// To be deprecated.
 	Txn() (kv.TxnStore, error)
 
-	// Store returns access to the distributed configuration store with a namespace
+	// Store returns access to the distributed configuration store with a namespace.
 	Store(namespace string) (kv.Store, error)
 
-	// TxnStore returns access to the transaction store with a namespace
+	// TxnStore returns access to the transaction store with a namespace.
 	TxnStore(namespace string) (kv.TxnStore, error)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -32,8 +32,16 @@ type Client interface {
 	Services() (services.Services, error)
 
 	// KV returns access to the distributed configuration store
+	// To be deprecated
 	KV() (kv.Store, error)
 
 	// Txn returns access to the transaction store
+	// To be deprecated
 	Txn() (kv.TxnStore, error)
+
+	// Store returns access to the distributed configuration store with a namespace
+	Store(namespace string) (kv.Store, error)
+
+	// TxnStore returns access to the transaction store with a namespace
+	TxnStore(namespace string) (kv.TxnStore, error)
 }

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	internalPrefix     = "_"
-	cacheFileSeparater = "_"
+	cacheFileSeparator = "_"
 	cacheFileSuffix    = ".json"
 	// TODO deprecate this once all keys are migrated to per service namespace
 	kvPrefix = "_kv"
@@ -222,7 +222,7 @@ func newClient(endpoints []string) (*clientv3.Client, error) {
 
 func (c *csclient) cacheFileFn(zone string) etcdkv.CacheFileFn {
 	return etcdkv.CacheFileFn(func(namespace string) string {
-		if c.opts.CacheDir() == "" || c.opts.Service() == "" {
+		if c.opts.CacheDir() == "" {
 			return ""
 		}
 		return filepath.Join(c.opts.CacheDir(), fileName(namespace, c.opts.Service(), zone))
@@ -232,16 +232,18 @@ func (c *csclient) cacheFileFn(zone string) etcdkv.CacheFileFn {
 func fileName(parts ...string) string {
 	// get non-empty parts
 	idx := 0
-	for _, part := range parts {
+	for i, part := range parts {
 		if part == "" {
 			continue
 		}
-		parts[idx] = part
+		if i != idx {
+			parts[idx] = part
+		}
 		idx++
 	}
 	parts = parts[:idx]
-	s := strings.Join(parts, cacheFileSeparater)
-	return strings.Replace(s, string(os.PathSeparator), cacheFileSeparater, -1) + cacheFileSuffix
+	s := strings.Join(parts, cacheFileSeparator)
+	return strings.Replace(s, string(os.PathSeparator), cacheFileSeparator, -1) + cacheFileSuffix
 }
 
 func validateTopLevelNamespace(namespace string) error {

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -21,6 +21,7 @@
 package etcd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,10 +41,14 @@ import (
 )
 
 const (
-	keySeparator    = "/"
-	cacheFileFormat = "%s-%s.json"
-	kvPrefix        = "_kv/"
+	internalPrefix     = "_"
+	cacheFileSeparater = "_"
+	cacheFileSuffix    = ".json"
+	// TODO deprecate this once all keys are migrated to per service namespace
+	kvPrefix = "_kv"
 )
+
+var errInvalidNamespace = errors.New("invalid namespace")
 
 type newClientFn func(endpoints []string) (*clientv3.Client, error)
 
@@ -83,9 +88,9 @@ type csclient struct {
 	sd     services.Services
 	sdErr  error
 
-	kvOnce sync.Once
-	kv     kv.TxnStore
-	kvErr  error
+	txnOnce sync.Once
+	txn     kv.TxnStore
+	txnErr  error
 }
 
 func (c *csclient) Services() (services.Services, error) {
@@ -95,27 +100,31 @@ func (c *csclient) Services() (services.Services, error) {
 }
 
 func (c *csclient) KV() (kv.Store, error) {
-	c.createTxnStore()
-
-	return c.kv, c.kvErr
+	return c.createTxnStore(kvPrefix)
 }
 
 func (c *csclient) Txn() (kv.TxnStore, error) {
-	c.createTxnStore()
+	return c.createTxnStore(kvPrefix)
 
-	return c.kv, c.kvErr
+}
+
+func (c *csclient) TxnStore(namespace string) (kv.TxnStore, error) {
+	if err := validateTopLevelNamespace(namespace); err != nil {
+		return nil, err
+	}
+
+	return c.createTxnStore(namespace)
+}
+
+func (c *csclient) Store(namespace string) (kv.Store, error) {
+	return c.TxnStore(namespace)
 }
 
 func (c *csclient) createServices() {
 	c.sdOnce.Do(func() {
 		c.sd, c.sdErr = sdclient.NewServices(c.opts.ServiceDiscoveryConfig().NewOptions().
 			SetHeartbeatGen(c.heartbeatGen()).
-			SetKVGen(c.kvGen(etcdkv.NewOptions().
-				SetInstrumentsOptions(instrument.NewOptions().
-					SetLogger(c.logger).
-					SetMetricsScope(c.kvScope),
-				)),
-			).
+			SetKVGen(c.kvGen()).
 			SetInstrumentsOptions(instrument.NewOptions().
 				SetLogger(c.logger).
 				SetMetricsScope(c.sdScope),
@@ -124,24 +133,36 @@ func (c *csclient) createServices() {
 	})
 }
 
-func (c *csclient) createTxnStore() {
-	c.kvOnce.Do(func() {
-		opts := etcdkv.NewOptions().
-			SetInstrumentsOptions(instrument.NewOptions().
-				SetLogger(c.logger).
-				SetMetricsScope(c.kvScope)).
-			SetPrefix(prefix(c.opts.Env()))
-		c.kv, c.kvErr = c.txnGen(opts, c.opts.Zone())
+func (c *csclient) createTxnStore(namespace string) (kv.TxnStore, error) {
+	c.txnOnce.Do(func() {
+		c.txn, c.txnErr = c.txnGen(c.opts.Zone(), namespace, c.opts.Env())
 	})
+	return c.txn, c.txnErr
 }
 
-func (c *csclient) kvGen(kvOpts etcdkv.Options) sdclient.KVGen {
+func (c *csclient) kvGen() sdclient.KVGen {
 	return sdclient.KVGen(func(zone string) (kv.Store, error) {
-		return c.txnGen(kvOpts, zone)
+		return c.txnGen(zone)
 	})
 }
 
-func (c *csclient) txnGen(kvOpts etcdkv.Options, zone string) (kv.TxnStore, error) {
+func (c *csclient) newkvOptions(zone string, namespaces ...string) etcdkv.Options {
+	opts := etcdkv.NewOptions().
+		SetInstrumentsOptions(instrument.NewOptions().
+			SetLogger(c.logger).
+			SetMetricsScope(c.kvScope)).
+		SetCacheFileFn(c.cacheFileFn(zone))
+
+	for _, namespace := range namespaces {
+		if namespace == "" {
+			continue
+		}
+		opts = opts.SetPrefix(opts.ApplyPrefix(namespace))
+	}
+	return opts
+}
+
+func (c *csclient) txnGen(zone string, namespaces ...string) (kv.TxnStore, error) {
 	cli, err := c.etcdClientGen(zone)
 	if err != nil {
 		return nil, err
@@ -150,7 +171,7 @@ func (c *csclient) txnGen(kvOpts etcdkv.Options, zone string) (kv.TxnStore, erro
 	return etcdkv.NewStore(
 		cli.KV,
 		cli.Watcher,
-		kvOpts.SetCacheFilePath(cacheFileForZone(c.opts.CacheDir(), kvOpts.ApplyPrefix(c.opts.Service()), zone)),
+		c.newkvOptions(zone, namespaces...),
 	)
 }
 
@@ -199,27 +220,33 @@ func newClient(endpoints []string) (*clientv3.Client, error) {
 	return clientv3.New(clientv3.Config{Endpoints: endpoints})
 }
 
-func cacheFileForZone(cacheDir, service, zone string) string {
-	if cacheDir == "" || service == "" || zone == "" {
-		return ""
+func (c *csclient) cacheFileFn(zone string) etcdkv.CacheFileFn {
+	return etcdkv.CacheFileFn(func(namespace string) string {
+		if c.opts.CacheDir() == "" || c.opts.Service() == "" {
+			return ""
+		}
+		return filepath.Join(c.opts.CacheDir(), fileName(namespace, c.opts.Service(), zone))
+	})
+}
+
+func fileName(parts ...string) string {
+	// get non-empty parts
+	idx := 0
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[idx] = part
+		idx++
 	}
-	return filepath.Join(cacheDir, fileName(service, zone))
+	parts = parts[:idx]
+	s := strings.Join(parts, cacheFileSeparater)
+	return strings.Replace(s, string(os.PathSeparator), cacheFileSeparater, -1) + cacheFileSuffix
 }
 
-func fileName(service, zone string) string {
-	cacheFileName := fmt.Sprintf(cacheFileFormat, service, zone)
-
-	return strings.Replace(cacheFileName, string(os.PathSeparator), "_", -1)
-}
-
-func prefix(env string) string {
-	res := kvPrefix
-	if env != "" {
-		res = concat(res, concat(env, keySeparator))
+func validateTopLevelNamespace(namespace string) error {
+	if strings.HasPrefix(namespace, internalPrefix) {
+		return errInvalidNamespace
 	}
-	return res
-}
-
-func concat(a, b string) string {
-	return fmt.Sprintf("%s%s", a, b)
+	return nil
 }

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/coreos/etcd/clientv3"
 	"github.com/m3db/m3cluster/client"
 	"github.com/m3db/m3cluster/kv"
 	etcdkv "github.com/m3db/m3cluster/kv/etcd"
@@ -37,6 +36,8 @@ import (
 	etcdheartbeat "github.com/m3db/m3cluster/services/heartbeat/etcd"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/log"
+
+	"github.com/coreos/etcd/clientv3"
 	"github.com/uber-go/tally"
 )
 

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -23,9 +23,10 @@ package etcd
 import (
 	"testing"
 
+	"github.com/m3db/m3cluster/services"
+
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/integration"
-	"github.com/m3db/m3cluster/services"
 	"github.com/stretchr/testify/require"
 )
 

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -26,69 +26,69 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/integration"
 	"github.com/m3db/m3cluster/services"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestETCDClientGen(t *testing.T) {
 	cs, err := NewConfigServiceClient(testOptions())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	c := cs.(*csclient)
-	// zone3 does not exist
-	_, err = c.etcdClientGen("zone3")
-	assert.Error(t, err)
-	assert.Equal(t, 0, len(c.clis))
+	// a zone that does not exist
+	_, err = c.etcdClientGen("not_exist")
+	require.Error(t, err)
+	require.Equal(t, 0, len(c.clis))
 
 	c1, err := c.etcdClientGen("zone1")
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(c.clis))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(c.clis))
 
 	c2, err := c.etcdClientGen("zone2")
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(c.clis))
-	assert.NotEqual(t, c1, c2)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(c.clis))
+	require.NotEqual(t, c1, c2)
 
 	c1Again, err := c.etcdClientGen("zone1")
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(c.clis))
-	assert.Equal(t, c1, c1Again)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(c.clis))
+	require.Equal(t, c1, c1Again)
 }
 
 func TestKVAndHeartbeatServiceSharingETCDClient(t *testing.T) {
 	sid := services.NewServiceID().SetName("s1")
 
 	cs, err := NewConfigServiceClient(testOptions().SetZone("zone1"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	c := cs.(*csclient)
 
 	_, err = c.KV()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(c.clis))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(c.clis))
 
 	_, err = c.heartbeatGen()(sid.SetZone("zone1"))
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(c.clis))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(c.clis))
 
 	_, err = c.heartbeatGen()(sid.SetZone("zone2"))
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(c.clis))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(c.clis))
 
-	_, err = c.heartbeatGen()(sid.SetZone("zone3"))
-	assert.Error(t, err)
-	assert.Equal(t, 2, len(c.clis))
+	_, err = c.heartbeatGen()(sid.SetZone("not_exist"))
+	require.Error(t, err)
+	require.Equal(t, 2, len(c.clis))
 }
 
 func TestClient(t *testing.T) {
 	_, err := NewConfigServiceClient(NewOptions())
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	cs, err := NewConfigServiceClient(testOptions())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = cs.KV()
-	assert.Error(t, err)
+	require.NoError(t, err)
 
-	cs, err = NewConfigServiceClient(testOptions().SetZone("zone1"))
+	cs, err = NewConfigServiceClient(testOptions())
 	c := cs.(*csclient)
 
 	fn, closer := testNewETCDFn(t)
@@ -96,72 +96,75 @@ func TestClient(t *testing.T) {
 	c.newFn = fn
 
 	txn, err := c.Txn()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kv1, err := c.KV()
-	assert.NoError(t, err)
-	assert.Equal(t, kv1, txn)
+	require.NoError(t, err)
+	require.Equal(t, kv1, txn)
 
 	kv2, err := c.KV()
-	assert.NoError(t, err)
-	assert.Equal(t, kv1, kv2)
+	require.NoError(t, err)
+	require.Equal(t, kv1, kv2)
 	// KV store will create an etcd cli for local zone only
-	assert.Equal(t, 1, len(c.clis))
+	require.Equal(t, 1, len(c.clis))
 	_, ok := c.clis["zone1"]
-	assert.True(t, ok)
+	require.True(t, ok)
 
 	sd1, err := c.Services()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sd2, err := c.Services()
-	assert.NoError(t, err)
-	assert.Equal(t, sd1, sd2)
-
-	err = sd1.SetMetadata(
-		services.NewServiceID().SetName("service").SetZone("zone1"),
-		services.NewMetadata(),
-	)
-	assert.NoError(t, err)
-	// etcd cli for zone1 will be reused
-	assert.Equal(t, 1, len(c.clis))
+	require.NoError(t, err)
+	require.Equal(t, sd1, sd2)
 
 	err = sd1.SetMetadata(
 		services.NewServiceID().SetName("service").SetZone("zone2"),
 		services.NewMetadata(),
 	)
-	assert.NoError(t, err)
-	// etcd cli for zone2 will be created since the request is going to zone2
-	assert.Equal(t, 2, len(c.clis))
+	require.NoError(t, err)
+	// etcd cli for zone1 will be reused
+	require.Equal(t, 2, len(c.clis))
 	_, ok = c.clis["zone2"]
-	assert.True(t, ok)
+	require.True(t, ok)
 
 	err = sd1.SetMetadata(
 		services.NewServiceID().SetName("service").SetZone("zone3"),
 		services.NewMetadata(),
 	)
-	// does not have etcd cluster for zone3
-	assert.Error(t, err)
-	assert.Equal(t, 2, len(c.clis))
+	require.NoError(t, err)
+	// etcd cli for zone2 will be created since the request is going to zone2
+	require.Equal(t, 3, len(c.clis))
+	_, ok = c.clis["zone3"]
+	require.True(t, ok)
 }
 
 func TestCacheFileForZone(t *testing.T) {
-	assert.Equal(t, "", cacheFileForZone("", "app", "zone"))
-	assert.Equal(t, "", cacheFileForZone("/dir", "", "zone"))
-	assert.Equal(t, "", cacheFileForZone("/dir", "app", ""))
-	assert.Equal(t, "/dir/app-zone.json", cacheFileForZone("/dir", "app", "zone"))
-	assert.Equal(t, "/dir/a_b-c_d.json", cacheFileForZone("/dir", "a/b", "c/d"))
-}
+	c, err := NewConfigServiceClient(testOptions())
+	require.NoError(t, err)
+	cs := c.(*csclient)
 
-func TestPrefix(t *testing.T) {
-	assert.Equal(t, "_kv/test/", prefix("test"))
-	assert.Equal(t, "_kv/", prefix(""))
+	kvOpts := cs.newkvOptions("z1", "namespace")
+	require.Equal(t, "", kvOpts.CacheFileFn()(kvOpts.Prefix()))
+
+	cs.opts = cs.opts.SetCacheDir("/cacheDir")
+	kvOpts = cs.newkvOptions("z1")
+	require.Equal(t, "/cacheDir/test_app_z1.json", kvOpts.CacheFileFn()(kvOpts.Prefix()))
+	kvOpts = cs.newkvOptions("z1", "namespace")
+	require.Equal(t, "/cacheDir/namespace_test_app_z1.json", kvOpts.CacheFileFn()(kvOpts.Prefix()))
+
+	kvOpts = cs.newkvOptions("z1", "namespace", "")
+	require.Equal(t, "/cacheDir/namespace_test_app_z1.json", kvOpts.CacheFileFn()(kvOpts.Prefix()))
+
+	kvOpts = cs.newkvOptions("z1", "namespace", "env")
+	require.Equal(t, "/cacheDir/namespace_env_test_app_z1.json", kvOpts.CacheFileFn()(kvOpts.Prefix()))
 }
 
 func testOptions() Options {
 	return NewOptions().SetClusters([]Cluster{
 		NewCluster().SetZone("zone1").SetEndpoints([]string{"i1"}),
 		NewCluster().SetZone("zone2").SetEndpoints([]string{"i2"}),
-	}).SetService("test_app")
+		NewCluster().SetZone("zone3").SetEndpoints([]string{"i3"}),
+	}).SetService("test_app").SetZone("zone1")
 }
 
 func testNewETCDFn(t *testing.T) (newClientFn, func()) {

--- a/kv/etcd/options.go
+++ b/kv/etcd/options.go
@@ -35,7 +35,11 @@ var (
 	defaultWatchChanResetInterval = 10 * time.Second
 	defaultWatchChanInitTimeout   = 10 * time.Second
 	defaultRetryOptions           = xretry.NewOptions().SetMaxRetries(5)
+	defaultCacheFileFn            = func(namespace string) string { return "" }
 )
+
+// CacheFileFn is a function to generate cache file path
+type CacheFileFn func(namespace string) string
 
 // Options are options for the client of the kv store
 type Options interface {
@@ -70,18 +74,17 @@ type Options interface {
 	// SetWatchChanInitTimeout sets the WatchChanInitTimeout
 	SetWatchChanInitTimeout(t time.Duration) Options
 
-	// CacheFilePath is the file path to persist in-memory cache.
-	// If not provided, not file persisting will happen
-	CacheFilePath() string
-	// SetCacheFilePath sets the CacheFilePath
-	SetCacheFilePath(c string) Options
-
 	// Prefix is the prefix for each key
 	Prefix() string
 	// SetPrefix sets the prefix
 	SetPrefix(s string) Options
 	// ApplyPrefix applies the prefix to the key
 	ApplyPrefix(key string) string
+
+	// CacheFileDir is the dir for cache.
+	CacheFileFn() CacheFileFn
+	// SetCacheFileDir sets the CacheFileDir
+	SetCacheFileFn(fn CacheFileFn) Options
 
 	// Validate validates the Options
 	Validate() error
@@ -95,7 +98,7 @@ type options struct {
 	watchChanCheckInterval time.Duration
 	watchChanResetInterval time.Duration
 	watchChanInitTimeout   time.Duration
-	cacheFilePath          string
+	cacheFileFn            CacheFileFn
 }
 
 // NewOptions creates a sane default Option
@@ -106,7 +109,8 @@ func NewOptions() Options {
 		SetRetryOptions(defaultRetryOptions).
 		SetWatchChanCheckInterval(defaultWatchChanCheckInterval).
 		SetWatchChanResetInterval(defaultWatchChanResetInterval).
-		SetWatchChanInitTimeout(defaultWatchChanInitTimeout)
+		SetWatchChanInitTimeout(defaultWatchChanInitTimeout).
+		SetCacheFileFn(defaultCacheFileFn)
 }
 
 func (o options) Validate() error {
@@ -179,12 +183,12 @@ func (o options) SetWatchChanInitTimeout(t time.Duration) Options {
 	return o
 }
 
-func (o options) CacheFilePath() string {
-	return o.cacheFilePath
+func (o options) CacheFileFn() CacheFileFn {
+	return o.cacheFileFn
 }
 
-func (o options) SetCacheFilePath(c string) Options {
-	o.cacheFilePath = c
+func (o options) SetCacheFileFn(fn CacheFileFn) Options {
+	o.cacheFileFn = fn
 	return o
 }
 
@@ -198,5 +202,8 @@ func (o options) SetPrefix(prefix string) Options {
 }
 
 func (o options) ApplyPrefix(key string) string {
-	return fmt.Sprintf("%s%s", o.prefix, key)
+	if o.prefix == "" {
+		return key
+	}
+	return fmt.Sprintf("%s/%s", o.prefix, key)
 }

--- a/kv/etcd/options.go
+++ b/kv/etcd/options.go
@@ -35,7 +35,7 @@ var (
 	defaultWatchChanResetInterval = 10 * time.Second
 	defaultWatchChanInitTimeout   = 10 * time.Second
 	defaultRetryOptions           = xretry.NewOptions().SetMaxRetries(5)
-	defaultCacheFileFn            = func(namespace string) string { return "" }
+	defaultCacheFileFn            = func(string) string { return "" }
 )
 
 // CacheFileFn is a function to generate cache file path

--- a/kv/etcd/store.go
+++ b/kv/etcd/store.go
@@ -59,7 +59,7 @@ func NewStore(etcdKV clientv3.KV, etcdWatcher clientv3.Watcher, opts Options) (k
 		watchables:     map[string]kv.ValueWatchable{},
 		retrier:        xretry.NewRetrier(opts.RetryOptions()),
 		logger:         opts.InstrumentsOptions().Logger(),
-		cacheFile:      opts.CacheFilePath(),
+		cacheFile:      opts.CacheFileFn()(opts.Prefix()),
 		cache:          newCache(),
 		cacheUpdatedCh: make(chan struct{}, 1),
 		m: clientMetrics{
@@ -576,7 +576,7 @@ func (c *client) writeCacheToFile() error {
 }
 
 func (c *client) initCache() error {
-	file, err := os.Open(c.opts.CacheFilePath())
+	file, err := os.Open(c.cacheFile)
 	if err != nil {
 		c.m.diskReadError.Inc(1)
 		return fmt.Errorf("error opening cache file %s: %v", c.cacheFile, err)

--- a/kv/etcd/store_test.go
+++ b/kv/etcd/store_test.go
@@ -119,7 +119,9 @@ func TestCache(t *testing.T) {
 	f, err := ioutil.TempFile("", "")
 	require.NoError(t, err)
 
-	opts = opts.SetCacheFilePath(f.Name())
+	opts = opts.SetCacheFileFn(func(string) string {
+		return f.Name()
+	})
 
 	store, err := NewStore(ec, ec, opts)
 	require.NoError(t, err)
@@ -789,7 +791,7 @@ func testStore(t *testing.T) (*clientv3.Client, Options, func()) {
 
 	opts := NewOptions().
 		SetWatchChanCheckInterval(10 * time.Millisecond).
-		SetPrefix("test/")
+		SetPrefix("test")
 
 	return ec, opts, closer
 }

--- a/services/client/services_test.go
+++ b/services/client/services_test.go
@@ -22,7 +22,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -781,7 +780,7 @@ func TestWatch_GetAfterTimeout(t *testing.T) {
 			etcdKV.NewOptions().
 				SetWatchChanInitTimeout(200*time.Millisecond).
 				SetWatchChanResetInterval(200*time.Millisecond).
-				SetPrefix(fmt.Sprintf("%s/", zone)),
+				SetPrefix(zone),
 		)
 	}
 
@@ -971,7 +970,7 @@ func testSetup(t *testing.T) (Options, func(), *mockHBGen) {
 			ec,
 			etcdKV.NewOptions().
 				SetWatchChanCheckInterval(100*time.Millisecond).
-				SetPrefix(fmt.Sprintf("%s/", zone)),
+				SetPrefix(zone),
 		)
 	}
 


### PR DESCRIPTION
This PR allows users to specify namespace when creating KV store as top level namespace to improve isolation between services.

This PR did not use the namespace feature in etcd because we need to upgrade to go 1.8 in order to use that, when we are ready to upgrade Go we can easily change the impl to use etcd namespace

@xichen2020 @jeromefroe  @dgromov 