### PR TITLE
placement no longer gets cloned for every shard in MarkShardAvaialble

### DIFF
--- a/services/placement/algo/non_sharded.go
+++ b/services/placement/algo/non_sharded.go
@@ -48,7 +48,7 @@ func (a nonShardedAlgorithm) InitialPlacement(
 	}
 
 	return placement.NewPlacement().
-		SetInstances(cloneInstances(instances)).
+		SetInstances(placement.CloneInstances(instances)).
 		SetShards(shards).
 		SetReplicaFactor(1).
 		SetIsSharded(false), nil
@@ -58,7 +58,7 @@ func (a nonShardedAlgorithm) AddReplica(p services.ServicePlacement) (services.S
 	if p.IsSharded() {
 		return nil, errNonShardedAlgoOnShardedPlacement
 	}
-	p = clonePlacement(p)
+	p = placement.ClonePlacement(p)
 	return placement.NewPlacement().
 		SetInstances(p.Instances()).
 		SetShards(p.Shards()).
@@ -70,7 +70,7 @@ func (a nonShardedAlgorithm) RemoveInstance(p services.ServicePlacement, instanc
 	if p.IsSharded() {
 		return nil, errNonShardedAlgoOnShardedPlacement
 	}
-	p = clonePlacement(p)
+	p = placement.ClonePlacement(p)
 	instances := p.Instances()
 	for i, instance := range instances {
 		if instance.ID() == instanceID {
@@ -93,7 +93,7 @@ func (a nonShardedAlgorithm) AddInstance(
 	if p.IsSharded() {
 		return nil, errNonShardedAlgoOnShardedPlacement
 	}
-	p = clonePlacement(p)
+	p = placement.ClonePlacement(p)
 	instances := p.Instances()
 	for _, instance := range instances {
 		if instance.ID() == i.ID() {

--- a/services/placement/algo/sharded.go
+++ b/services/placement/algo/sharded.go
@@ -44,7 +44,7 @@ func newShardedAlgorithm(opts services.PlacementOptions) placement.Algorithm {
 }
 
 func (a rackAwarePlacementAlgorithm) InitialPlacement(instances []services.PlacementInstance, shards []uint32) (services.ServicePlacement, error) {
-	ph := newInitHelper(cloneInstances(instances), shards, a.opts)
+	ph := newInitHelper(placement.CloneInstances(instances), shards, a.opts)
 
 	if err := ph.PlaceShards(newShards(shards), nil, ph.Instances()); err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func (a rackAwarePlacementAlgorithm) AddReplica(p services.ServicePlacement) (se
 		return nil, errShardedAlgoOnNotShardedPlacement
 	}
 
-	p = clonePlacement(p)
+	p = placement.ClonePlacement(p)
 	ph := newAddReplicaHelper(p, a.opts)
 	if err := ph.PlaceShards(newShards(p.Shards()), nil, ph.Instances()); err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func (a rackAwarePlacementAlgorithm) RemoveInstance(p services.ServicePlacement,
 		return nil, errShardedAlgoOnNotShardedPlacement
 	}
 
-	p = clonePlacement(p)
+	p = placement.ClonePlacement(p)
 	ph, leavingInstance, err := newRemoveInstanceHelper(p, instanceID, a.opts)
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func (a rackAwarePlacementAlgorithm) AddInstance(
 		return nil, errShardedAlgoOnNotShardedPlacement
 	}
 
-	p, addingInstance = clonePlacement(p), cloneInstance(addingInstance)
+	p, addingInstance = placement.ClonePlacement(p), placement.CloneInstance(addingInstance)
 	instance, exist := p.Instance(addingInstance.ID())
 	if exist {
 		if !placement.IsInstanceLeaving(instance) {
@@ -120,7 +120,7 @@ func (a rackAwarePlacementAlgorithm) ReplaceInstance(
 		return nil, errShardedAlgoOnNotShardedPlacement
 	}
 
-	p = clonePlacement(p)
+	p = placement.ClonePlacement(p)
 	ph, leavingInstance, addingInstances, err := newReplaceInstanceHelper(p, instanceID, addingInstances, a.opts)
 	if err != nil {
 		return nil, err

--- a/services/placement/algo/sharded_test.go
+++ b/services/placement/algo/sharded_test.go
@@ -368,9 +368,9 @@ func TestRemoveInitializingInstance(t *testing.T) {
 	p, err := a.InitialPlacement([]services.PlacementInstance{i1}, []uint32{1, 2})
 	assert.NoError(t, err)
 
-	p, err = MarkShardAvailable(p, "i1", 1)
+	p, err = placement.MarkShardAvailable(p, "i1", 1)
 	assert.NoError(t, err)
-	p, err = MarkShardAvailable(p, "i1", 2)
+	p, err = placement.MarkShardAvailable(p, "i1", 2)
 	assert.NoError(t, err)
 
 	instance1, ok := p.Instance("i1")
@@ -1056,15 +1056,8 @@ func TestShardedAlgoOnNonShardedPlacement(t *testing.T) {
 }
 
 func markAllShardsAsAvailable(t *testing.T, p services.ServicePlacement) services.ServicePlacement {
-	var err error
-	for _, instance := range p.Instances() {
-		for _, s := range instance.Shards().All() {
-			if s.State() == shard.Initializing {
-				p, err = MarkShardAvailable(p, instance.ID(), s.ID())
-				assert.NoError(t, err)
-			}
-		}
-	}
+	p, err := placement.MarkAllShardsAsAvailable(p)
+	assert.NoError(t, err)
 	return p
 }
 

--- a/services/placement/service/placementservice.go
+++ b/services/placement/service/placementservice.go
@@ -91,7 +91,7 @@ func (ps placementService) BuildInitialPlacement(
 
 	// NB(r): All new placements should appear as available for
 	// proper client semantics when calculating consistency results
-	p, err = markAllShardsAsAvailable(p)
+	p, err = placement.MarkAllShardsAsAvailable(p)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (ps placementService) MarkShardAvailable(instanceID string, shardID uint32)
 		return err
 	}
 
-	p, err = algo.MarkShardAvailable(p, instanceID, shardID)
+	p, err = placement.MarkShardAvailable(p, instanceID, shardID)
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func (ps placementService) MarkInstanceAvailable(instanceID string) error {
 		if s.State() != shard.Initializing {
 			continue
 		}
-		p, err = algo.MarkShardAvailable(p, instanceID, s.ID())
+		p, err = placement.MarkShardAvailable(p, instanceID, s.ID())
 		if err != nil {
 			return err
 		}
@@ -571,19 +571,4 @@ func (things sortableThings) Less(i, j int) bool {
 
 func (things sortableThings) Swap(i, j int) {
 	things[i], things[j] = things[j], things[i]
-}
-
-func markAllShardsAsAvailable(p services.ServicePlacement) (services.ServicePlacement, error) {
-	var err error
-	for _, instance := range p.Instances() {
-		for _, s := range instance.Shards().All() {
-			if s.State() == shard.Initializing {
-				p, err = algo.MarkShardAvailable(p, instance.ID(), s.ID())
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-	}
-	return p, nil
 }

--- a/services/placement/service/placementservice_test.go
+++ b/services/placement/service/placementservice_test.go
@@ -47,6 +47,19 @@ func TestGoodWorkflow(t *testing.T) {
 	testGoodWorkflow(t, p)
 }
 
+func TestManyShards(t *testing.T) {
+	p := NewPlacementService(NewMockStorage(), testServiceID(), placement.NewOptions())
+	i1 := placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 2)
+	i2 := placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 2)
+	i3 := placement.NewEmptyInstance("i3", "r3", "z1", "endpoint", 2)
+	i4 := placement.NewEmptyInstance("i4", "r1", "z1", "endpoint", 2)
+	i5 := placement.NewEmptyInstance("i5", "r2", "z1", "endpoint", 2)
+	i6 := placement.NewEmptyInstance("i6", "r3", "z1", "endpoint", 2)
+	_, err := p.BuildInitialPlacement([]services.PlacementInstance{i1, i2, i3, i4, i5, i6}, 8192, 1)
+
+	assert.NoError(t, err)
+}
+
 func assertPlacementInstanceEqualExceptShards(
 	t *testing.T,
 	expected services.PlacementInstance,


### PR DESCRIPTION
The placement clone is now create once before going through all the
shards. This commit also moves a bunch of stuff into placement.go from
the algo module.