### PR TITLE
Remove namespace from watcher configuration

### DIFF
--- a/services/placement/config.go
+++ b/services/placement/config.go
@@ -23,16 +23,13 @@ package placement
 import (
 	"time"
 
-	"github.com/m3db/m3cluster/client"
+	"github.com/m3db/m3cluster/kv"
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3x/instrument"
 )
 
 // WatcherConfiguration contains placement watcher configuration.
 type WatcherConfiguration struct {
-	// Placement kv namespace.
-	Namespace string `yaml:"namespace" validate:"nonzero"`
-
 	// Placement key.
 	Key string `yaml:"key" validate:"nonzero"`
 
@@ -42,14 +39,9 @@ type WatcherConfiguration struct {
 
 // NewOptions creates a placement watcher option.
 func (c *WatcherConfiguration) NewOptions(
-	client client.Client,
+	store kv.Store,
 	instrumentOpts instrument.Options,
-) (services.StagedPlacementWatcherOptions, error) {
-	store, err := client.Store(c.Namespace)
-	if err != nil {
-		return nil, err
-	}
-
+) services.StagedPlacementWatcherOptions {
 	opts := NewStagedPlacementWatcherOptions().
 		SetInstrumentOptions(instrumentOpts).
 		SetStagedPlacementKey(c.Key).
@@ -57,5 +49,5 @@ func (c *WatcherConfiguration) NewOptions(
 	if c.InitWatchTimeout != 0 {
 		opts = opts.SetInitWatchTimeout(c.InitWatchTimeout)
 	}
-	return opts, nil
+	return opts
 }

--- a/services/placement/config_test.go
+++ b/services/placement/config_test.go
@@ -24,31 +24,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3cluster/client"
 	"github.com/m3db/m3cluster/kv/mem"
 	"github.com/m3db/m3x/instrument"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWatcherConfiguration(t *testing.T) {
 	cfg := &WatcherConfiguration{
-		Namespace:        "ns",
 		Key:              "key",
 		InitWatchTimeout: time.Second,
 	}
 
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	m := client.NewMockClient(ctrl)
-
 	mem := mem.NewStore()
-	m.EXPECT().Store(cfg.Namespace).Return(mem, nil)
-	opts, err := cfg.NewOptions(m, instrument.NewOptions())
-	require.NoError(t, err)
-
+	opts := cfg.NewOptions(mem, instrument.NewOptions())
 	require.Equal(t, cfg.Key, opts.StagedPlacementKey())
 	require.Equal(t, cfg.InitWatchTimeout, opts.InitWatchTimeout())
 	require.Equal(t, mem, opts.StagedPlacementStore())


### PR DESCRIPTION
cc @jeromefroe 

This PR removes namespace from watcher configuration and instead explicitly pass in the kv store so we can create the store outside the config and reuse the store if needed.