### PR TITLE
[glide] Update tally dependency to be compatible with any 3.x.x version

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0e43a47cd36661a3a903d41111eaacd02f96e9ddaa601dd57905d43b45d455af
-updated: 2017-07-21T11:58:38.592029793-04:00
+hash: ae0fb14a2cca679a0203d3ca3a4526370f4050a4adc75e7dbb96d918e5a0773b
+updated: 2017-08-18T15:03:26.163638092-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -149,7 +149,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
+  version: 9e0844febd9e2856f839c9cb974fbd676d1755a8
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,7 +25,7 @@ import:
 - package: github.com/prometheus/client_model
   version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
 - package: github.com/uber-go/tally
-  version: 3.0.0
+  version: ^3.0.0 # ie >= 3.0.0, < 4.0.0
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
 - package: github.com/uber-go/atomic


### PR DESCRIPTION
To take advantage of the new sanitization features of `tally` we need to use the newest release which is `3.1.0`. However, we pin the version of `tally` to `3.0.0` in many of the repos under `m3db` which means that any package which depends on them cannot upgrade. This PR, therefore, is to change the version of `tally` from `3.0.0` to `^3.0.0`, so we can use any `3.x.x` release.

cc @xichen2020 @prateek 