### PR TITLE
[util] Add utility functions for validating updates to watch variables

### DIFF
--- a/kv/util/types.go
+++ b/kv/util/types.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3x/log"
+)
+
+// ValidateFn validates an update from KV.
+type ValidateFn func(interface{}) error
+
+type getValueFn func(kv.Value) (interface{}, error)
+
+type updateFn func(interface{})
+
+// Options is a set of options for kv utility functions.
+type Options interface {
+	// SetValidateFn sets the validation function applied to kv values.
+	SetValidateFn(val ValidateFn) Options
+
+	// ValidateFn returns the validation function applied to kv values.
+	ValidateFn() ValidateFn
+
+	// SetLogger sets the logger.
+	SetLogger(val xlog.Logger) Options
+
+	// Logger returns the logger.
+	Logger() xlog.Logger
+}
+
+type options struct {
+	validateFn ValidateFn
+	logger     xlog.Logger
+}
+
+// NewOptions returns a new set of options for kv utility functions.
+func NewOptions() Options {
+	return &options{}
+}
+
+func (o *options) SetValidateFn(val ValidateFn) Options {
+	opts := *o
+	opts.validateFn = val
+	return &opts
+}
+
+func (o *options) ValidateFn() ValidateFn {
+	return o.validateFn
+}
+
+func (o *options) SetLogger(val xlog.Logger) Options {
+	opts := *o
+	opts.logger = val
+	return &opts
+}
+
+func (o *options) Logger() xlog.Logger {
+	return o.logger
+}

--- a/kv/util/util.go
+++ b/kv/util/util.go
@@ -37,10 +37,11 @@ var (
 
 // WatchAndUpdateBool sets up a watch with validation for a bool property. Any
 // malformed or invalid updates are not applied. The default value is applied
-// when the key is does not exist in KV.
+// when the key does not exist in KV.
 func WatchAndUpdateBool(
 	store kv.Store,
-	key string, property *bool,
+	key string,
+	property *bool,
 	lock sync.Locker,
 	defaultValue bool,
 	opts Options,
@@ -57,7 +58,7 @@ func WatchAndUpdateBool(
 
 // WatchAndUpdateFloat64 sets up a watch with validation for a float64 property.
 // Any malformed or invalid updates are not applied. The default value is applied
-// when the key is does not exist in KV.
+// when the key does not exist in KV.
 func WatchAndUpdateFloat64(
 	store kv.Store,
 	key string,
@@ -78,7 +79,7 @@ func WatchAndUpdateFloat64(
 
 // WatchAndUpdateInt64 sets up a watch with validation for an int64 property. Any
 // malformed or invalid updates are not applied. The default value is applied when
-// the key is does not exist in KV.
+// the key does not exist in KV.
 func WatchAndUpdateInt64(
 	store kv.Store,
 	key string,
@@ -99,7 +100,7 @@ func WatchAndUpdateInt64(
 
 // WatchAndUpdateString sets up a watch with validation for a string property. Any
 // malformed or invalid updates are not applied. The default value is applied when
-// the key is does not exist in KV.
+// the key does not exist in KV.
 func WatchAndUpdateString(
 	store kv.Store,
 	key string,
@@ -118,9 +119,9 @@ func WatchAndUpdateString(
 	)
 }
 
-// WatchAndUpdateStringArray sets up a watch with validation for a string property.
-// Any malformed, or invalid updates are not applied. The default value is applied
-// when the key is does not exist in KV.
+// WatchAndUpdateStringArray sets up a watch with validation for a string array
+// property. Any malformed, or invalid updates are not applied. The default value
+// is applied when the key does not exist in KV.
 func WatchAndUpdateStringArray(
 	store kv.Store,
 	key string,
@@ -141,7 +142,7 @@ func WatchAndUpdateStringArray(
 
 // WatchAndUpdateTime sets up a watch with validation for a time property. Any
 // malformed, or invalid updates are not applied. The default value is applied
-// when the key is does not exist in KV.
+// when the key does not exist in KV.
 func WatchAndUpdateTime(
 	store kv.Store,
 	key string,
@@ -413,7 +414,7 @@ func updateWithKV(
 func logNilUpdate(logger xlog.Logger, k string, v interface{}) {
 	getLogger(logger).WithFields(
 		xlog.NewLogField("key", k),
-		xlog.NewLogField("value", v),
+		xlog.NewLogField("default-value", v),
 	).Warnf("nil value from kv store, applying default value")
 }
 

--- a/kv/util/util.go
+++ b/kv/util/util.go
@@ -39,70 +39,24 @@ type getValueFn func(kv.Value) (interface{}, error)
 
 type updateFn func(interface{})
 
-// WatchAndUpdateBool sets up a watch for a bool property.
+// WatchAndUpdateBool sets up a watch with validation for a bool property. Any invalid
+// updates are not applied.
 func WatchAndUpdateBool(
 	store kv.Store,
 	key string, property *bool,
 	lock sync.Locker,
 	defaultValue bool,
+	validate ValidateFn,
 	logger xlog.Logger,
 ) (kv.ValueWatch, error) {
 	updateFn := lockedUpdate(func(i interface{}) { *property = i.(bool) }, lock)
 
-	return watchAndUpdate(store, key, getBool, updateFn, nil, defaultValue, logger)
+	return watchAndUpdate(store, key, getBool, updateFn, validate, defaultValue, logger)
 }
 
-// WatchAndUpdateFloat64 sets up a watch for a float64 property.
+// WatchAndUpdateFloat64 sets up a watch with validation for a float64 property. Any
+// invalid updates are not applied.
 func WatchAndUpdateFloat64(
-	store kv.Store,
-	key string,
-	property *float64,
-	lock sync.Locker,
-	defaultValue float64,
-	logger xlog.Logger,
-) (kv.ValueWatch, error) {
-	return WatchAndUpdateWithValidationFloat64(store, key, property, lock, defaultValue, nil, logger)
-}
-
-// WatchAndUpdateInt64 sets up a watch for an int64 property.
-func WatchAndUpdateInt64(
-	store kv.Store,
-	key string,
-	property *int64,
-	lock sync.Locker,
-	defaultValue int64,
-	logger xlog.Logger,
-) (kv.ValueWatch, error) {
-	return WatchAndUpdateWithValidationInt64(store, key, property, lock, defaultValue, nil, logger)
-}
-
-// WatchAndUpdateString sets up a watch for a string property.
-func WatchAndUpdateString(
-	store kv.Store,
-	key string,
-	property *string,
-	lock sync.Locker,
-	defaultValue string,
-	logger xlog.Logger,
-) (kv.ValueWatch, error) {
-	return WatchAndUpdateWithValidationString(store, key, property, lock, defaultValue, nil, logger)
-}
-
-// WatchAndUpdateTime sets up a watch for a time property.
-func WatchAndUpdateTime(
-	store kv.Store,
-	key string,
-	property *time.Time,
-	lock sync.Locker,
-	defaultValue time.Time,
-	logger xlog.Logger,
-) (kv.ValueWatch, error) {
-	return WatchAndUpdateWithValidationTime(store, key, property, lock, defaultValue, nil, logger)
-}
-
-// WatchAndUpdateWithValidationFloat64 sets up a watch with validation for a float64
-// property. Any invalid updates are not applied.
-func WatchAndUpdateWithValidationFloat64(
 	store kv.Store,
 	key string,
 	property *float64,
@@ -116,9 +70,9 @@ func WatchAndUpdateWithValidationFloat64(
 	return watchAndUpdate(store, key, getFloat64, updateFn, validate, defaultValue, logger)
 }
 
-// WatchAndUpdateWithValidationInt64 sets up a watch with validation for an int64
-// property. Any invalid updates are not applied.
-func WatchAndUpdateWithValidationInt64(
+// WatchAndUpdateInt64 sets up a watch with validation for an int64 property. Any
+// invalid updates are not applied.
+func WatchAndUpdateInt64(
 	store kv.Store,
 	key string,
 	property *int64,
@@ -132,9 +86,9 @@ func WatchAndUpdateWithValidationInt64(
 	return watchAndUpdate(store, key, getInt64, updateFn, validate, defaultValue, logger)
 }
 
-// WatchAndUpdateWithValidationString sets up a watch with validation for a string
-// property. Any invalid updates are not applied.
-func WatchAndUpdateWithValidationString(
+// WatchAndUpdateString sets up a watch with validation for a string property. Any
+// invalid updates are not applied.
+func WatchAndUpdateString(
 	store kv.Store,
 	key string,
 	property *string,
@@ -148,9 +102,9 @@ func WatchAndUpdateWithValidationString(
 	return watchAndUpdate(store, key, getString, updateFn, validate, defaultValue, logger)
 }
 
-// WatchAndUpdateWithValidationTime sets up a watch with validation for a time property.
-// Any invalid updates are not applied.
-func WatchAndUpdateWithValidationTime(
+// WatchAndUpdateTime sets up a watch with validation for a time property. Any invalid
+// updates are not applied.
+func WatchAndUpdateTime(
 	store kv.Store,
 	key string,
 	property *time.Time,
@@ -349,7 +303,7 @@ func logSetDefault(logger xlog.Logger, k string, v interface{}) {
 	getLogger(logger).WithFields(
 		xlog.NewLogField("key", k),
 		xlog.NewLogField("value", v),
-	).Warnf("nil value from kv store, use default value")
+	).Warnf("nil value from kv store, using default value")
 }
 
 func logUpdateSuccess(logger xlog.Logger, k string, ver int, v interface{}) {
@@ -366,7 +320,7 @@ func logMalformedUpdate(logger xlog.Logger, k string, ver int, v interface{}, er
 		xlog.NewLogField("value", v),
 		xlog.NewLogField("version", ver),
 		xlog.NewLogField("error", err),
-	).Warnf("malformed value from kv store, use default value")
+	).Warnf("malformed value from kv store, using default value")
 }
 
 func logInvalidUpdate(logger xlog.Logger, k string, ver int, v interface{}, err error) {

--- a/kv/util/util_test.go
+++ b/kv/util/util_test.go
@@ -441,7 +441,7 @@ func TestWatchAndUpdateWithValidationBool(t *testing.T) {
 		}
 	}
 
-	// Invalid update.
+	// Invalid updates should not be applied.
 	_, err = store.Set("foo", &commonpb.BoolProto{Value: false})
 	require.NoError(t, err)
 	for {

--- a/kv/util/util_test.go
+++ b/kv/util/util_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3cluster/generated/proto/commonpb"
 	"github.com/m3db/m3cluster/kv"
 	"github.com/m3db/m3cluster/kv/mem"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/kv/util/util_test.go
+++ b/kv/util/util_test.go
@@ -449,24 +449,6 @@ func TestWatchAndUpdateWithValidationBool(t *testing.T) {
 			break
 		}
 	}
-
-	_, err = store.Set("foo", &commonpb.Float64Proto{Value: 20})
-	require.NoError(t, err)
-	for {
-		if valueFn() {
-			break
-		}
-	}
-
-	_, err = store.Delete("foo")
-	require.NoError(t, err)
-	for {
-		if valueFn() {
-			break
-		}
-	}
-
-	require.NoError(t, err)
 }
 
 func TestWatchAndUpdateWithValidationFloat64(t *testing.T) {

--- a/kv/util/util_test.go
+++ b/kv/util/util_test.go
@@ -353,7 +353,7 @@ func TestWatchAndUpdateWithValidationFloat64(t *testing.T) {
 		}
 	}
 
-	// Invalid value.
+	// Invalid update.
 	_, err = store.Set("foo", &commonpb.Float64Proto{Value: 22})
 	require.NoError(t, err)
 	for {
@@ -429,7 +429,7 @@ func TestWatchAndUpdateWithValidationInt64(t *testing.T) {
 		}
 	}
 
-	// Invalid value.
+	// Invalid update.
 	_, err = store.Set("foo", &commonpb.Int64Proto{Value: 22})
 	require.NoError(t, err)
 	for {
@@ -505,7 +505,7 @@ func TestWatchAndUpdateWithValidationString(t *testing.T) {
 		}
 	}
 
-	// Invalid value.
+	// Invalid update.
 	_, err = store.Set("foo", &commonpb.StringProto{Value: "cat"})
 	require.NoError(t, err)
 	for {
@@ -590,7 +590,7 @@ func TestWatchAndUpdateWithValidationTime(t *testing.T) {
 		}
 	}
 
-	// Invalid value.
+	// Invalid update.
 	invalidTime := defaultTime.Add(2 * time.Minute)
 	_, err = store.Set("foo", &commonpb.Int64Proto{Value: invalidTime.Unix()})
 	require.NoError(t, err)


### PR DESCRIPTION
This PR adds utility functions to `kv` to watch for updates and validate that the updates fall within the pre-specified bounds. These functions will promote defensive programming and help callers guard against incorrect values being set in KV. I took a narrow approach here, only validating bounds for numeric types, but it might make sense to expand these changes to a more generic `validate` function that can check any type.

Update: Decided to take Prateek's advice and make the validation function more agnostic to the validation that should be performed.

cc @cw9 @xichen2020 @prateek 