### PR TITLE
Support custom namespace override in service discovery

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,10 +29,7 @@ import (
 // access to cluster services.
 type Client interface {
 	// Services returns access to the set of services.
-	Services() (services.Services, error)
-
-	// ServiceDiscovery returns service discovery with custom namespaces.
-	ServiceDiscovery(opts services.Options) (services.Services, error)
+	Services(opts services.Options) (services.Services, error)
 
 	// KV returns access to the distributed configuration store.
 	// To be deprecated.

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -100,15 +100,7 @@ type csclient struct {
 	txnErr  error
 }
 
-func (c *csclient) Services() (services.Services, error) {
-	c.defaultServicesOnce.Do(func() {
-		c.defaultServices, c.defaultServicesErr = c.createServices(services.NewOptions())
-	})
-
-	return c.defaultServices, c.defaultServicesErr
-}
-
-func (c *csclient) ServiceDiscovery(opts services.Options) (services.Services, error) {
+func (c *csclient) Services(opts services.Options) (services.Services, error) {
 	return c.createServices(opts)
 }
 

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -55,6 +55,8 @@ var errInvalidNamespace = errors.New("invalid namespace")
 
 type newClientFn func(endpoints []string) (*clientv3.Client, error)
 
+type cacheFileForZoneFn func(zone string) etcdkv.CacheFileFn
+
 // NewConfigServiceClient returns a ConfigServiceClient
 func NewConfigServiceClient(opts Options) (client.Client, error) {
 	if err := opts.Validate(); err != nil {
@@ -67,6 +69,7 @@ func NewConfigServiceClient(opts Options) (client.Client, error) {
 
 	return &csclient{
 		opts:    opts,
+		sdOpts:  opts.ServiceDiscoveryConfig().NewOptions(),
 		kvScope: scope.Tagged(map[string]string{"config_service": "kv"}),
 		sdScope: scope.Tagged(map[string]string{"config_service": "sd"}),
 		hbScope: scope.Tagged(map[string]string{"config_service": "hb"}),
@@ -81,6 +84,7 @@ type csclient struct {
 	clis map[string]*clientv3.Client
 
 	opts    Options
+	sdOpts  sdclient.Options
 	kvScope tally.Scope
 	sdScope tally.Scope
 	hbScope tally.Scope
@@ -97,9 +101,15 @@ type csclient struct {
 }
 
 func (c *csclient) Services() (services.Services, error) {
-	c.createServices()
+	c.sdOnce.Do(func() {
+		c.sd, c.sdErr = c.createServices(services.NewOptions())
+	})
 
 	return c.sd, c.sdErr
+}
+
+func (c *csclient) ServiceDiscovery(opts services.Options) (services.Services, error) {
+	return c.createServices(opts)
 }
 
 func (c *csclient) KV() (kv.Store, error) {
@@ -114,6 +124,10 @@ func (c *csclient) Txn() (kv.TxnStore, error) {
 	return c.txn, c.txnErr
 }
 
+func (c *csclient) Store(namespace string) (kv.Store, error) {
+	return c.TxnStore(namespace)
+}
+
 func (c *csclient) TxnStore(namespace string) (kv.TxnStore, error) {
 	namespace, err := validateTopLevelNamespace(namespace)
 	if err != nil {
@@ -123,40 +137,37 @@ func (c *csclient) TxnStore(namespace string) (kv.TxnStore, error) {
 	return c.createTxnStore(namespace)
 }
 
-func (c *csclient) Store(namespace string) (kv.Store, error) {
-	return c.TxnStore(namespace)
-}
-
-func (c *csclient) createServices() {
-	c.sdOnce.Do(func() {
-		c.sd, c.sdErr = sdclient.NewServices(c.opts.ServiceDiscoveryConfig().NewOptions().
-			SetHeartbeatGen(c.heartbeatGen()).
-			SetKVGen(c.kvGen()).
-			SetLeaderGen(c.leaderGen()).
-			SetInstrumentsOptions(instrument.NewOptions().
-				SetLogger(c.logger).
-				SetMetricsScope(c.sdScope),
-			),
-		)
-	})
+func (c *csclient) createServices(opts services.Options) (services.Services, error) {
+	nOpts := opts.NamespaceOptions()
+	cacheFileExtraFields := []string{nOpts.PlacementNamespace(), nOpts.MetadataNamespace()}
+	return sdclient.NewServices(c.sdOpts.
+		SetHeartbeatGen(c.heartbeatGen()).
+		SetKVGen(c.kvGen(c.cacheFileFn(cacheFileExtraFields...))).
+		SetLeaderGen(c.leaderGen()).
+		SetNamespaceOptions(opts.NamespaceOptions()).
+		SetInstrumentsOptions(instrument.NewOptions().
+			SetLogger(c.logger).
+			SetMetricsScope(c.sdScope),
+		),
+	)
 }
 
 func (c *csclient) createTxnStore(namespace string) (kv.TxnStore, error) {
-	return c.txnGen(c.opts.Zone(), namespace, c.opts.Env())
+	return c.txnGen(c.opts.Zone(), c.cacheFileFn(), namespace, c.opts.Env())
 }
 
-func (c *csclient) kvGen() sdclient.KVGen {
+func (c *csclient) kvGen(fn cacheFileForZoneFn) sdclient.KVGen {
 	return sdclient.KVGen(func(zone string) (kv.Store, error) {
-		return c.txnGen(zone)
+		return c.txnGen(zone, fn)
 	})
 }
 
-func (c *csclient) newkvOptions(zone string, namespaces ...string) etcdkv.Options {
+func (c *csclient) newkvOptions(zone string, cacheFileFn cacheFileForZoneFn, namespaces ...string) etcdkv.Options {
 	opts := etcdkv.NewOptions().
 		SetInstrumentsOptions(instrument.NewOptions().
 			SetLogger(c.logger).
 			SetMetricsScope(c.kvScope)).
-		SetCacheFileFn(c.cacheFileFn(zone))
+		SetCacheFileFn(cacheFileFn(zone))
 
 	for _, namespace := range namespaces {
 		if namespace == "" {
@@ -167,7 +178,7 @@ func (c *csclient) newkvOptions(zone string, namespaces ...string) etcdkv.Option
 	return opts
 }
 
-func (c *csclient) txnGen(zone string, namespaces ...string) (kv.TxnStore, error) {
+func (c *csclient) txnGen(zone string, cacheFileFn cacheFileForZoneFn, namespaces ...string) (kv.TxnStore, error) {
 	cli, err := c.etcdClientGen(zone)
 	if err != nil {
 		return nil, err
@@ -176,7 +187,7 @@ func (c *csclient) txnGen(zone string, namespaces ...string) (kv.TxnStore, error
 	return etcdkv.NewStore(
 		cli.KV,
 		cli.Watcher,
-		c.newkvOptions(zone, namespaces...),
+		c.newkvOptions(zone, cacheFileFn, namespaces...),
 	)
 }
 
@@ -242,13 +253,17 @@ func newClient(endpoints []string) (*clientv3.Client, error) {
 	return clientv3.New(clientv3.Config{Endpoints: endpoints})
 }
 
-func (c *csclient) cacheFileFn(zone string) etcdkv.CacheFileFn {
-	return etcdkv.CacheFileFn(func(namespace string) string {
-		if c.opts.CacheDir() == "" {
-			return ""
-		}
-		return filepath.Join(c.opts.CacheDir(), fileName(namespace, c.opts.Service(), zone))
-	})
+func (c *csclient) cacheFileFn(extraFields ...string) cacheFileForZoneFn {
+	return func(zone string) etcdkv.CacheFileFn {
+		return etcdkv.CacheFileFn(func(namespace string) string {
+			if c.opts.CacheDir() == "" {
+				return ""
+			}
+			cacheFileFields := []string{namespace, c.opts.Service(), zone}
+			cacheFileFields = append(cacheFileFields, extraFields...)
+			return filepath.Join(c.opts.CacheDir(), fileName(cacheFileFields...))
+		})
+	}
 }
 
 func fileName(parts ...string) string {

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -97,6 +97,9 @@ type csclient struct {
 }
 
 func (c *csclient) Services(opts services.Options) (services.Services, error) {
+	if opts == nil {
+		opts = services.NewOptions()
+	}
 	return c.createServices(opts)
 }
 

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -91,10 +91,6 @@ type csclient struct {
 	logger  xlog.Logger
 	newFn   newClientFn
 
-	defaultServicesOnce sync.Once
-	defaultServices     services.Services
-	defaultServicesErr  error
-
 	txnOnce sync.Once
 	txn     kv.TxnStore
 	txnErr  error

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -117,7 +117,7 @@ func TestClient(t *testing.T) {
 	_, ok := c.clis["zone1"]
 	require.True(t, ok)
 
-	sd1, err := c.Services()
+	sd1, err := c.Services(services.NewOptions())
 	require.NoError(t, err)
 
 	err = sd1.SetMetadata(
@@ -150,11 +150,11 @@ func TestServicesWithNamespace(t *testing.T) {
 	defer closer()
 	c.newFn = fn
 
-	sd1, err := c.Services()
+	sd1, err := c.Services(services.NewOptions())
 	require.NoError(t, err)
 
 	nOpts := services.NewNamespaceOptions().SetPlacementNamespace("p").SetMetadataNamespace("m")
-	sd2, err := c.ServiceDiscovery(services.NewOptions().SetNamespaceOptions(nOpts))
+	sd2, err := c.Services(services.NewOptions().SetNamespaceOptions(nOpts))
 	require.NoError(t, err)
 
 	require.NotEqual(t, sd1, sd2)

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -117,7 +117,7 @@ func TestClient(t *testing.T) {
 	_, ok := c.clis["zone1"]
 	require.True(t, ok)
 
-	sd1, err := c.Services(services.NewOptions())
+	sd1, err := c.Services(nil)
 	require.NoError(t, err)
 
 	err = sd1.SetMetadata(

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -120,10 +120,6 @@ func TestClient(t *testing.T) {
 	sd1, err := c.Services()
 	require.NoError(t, err)
 
-	sd2, err := c.Services()
-	require.NoError(t, err)
-	require.Equal(t, sd1, sd2)
-
 	err = sd1.SetMetadata(
 		services.NewServiceID().SetName("service").SetZone("zone2"),
 		services.NewMetadata(),

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -23,10 +23,10 @@ package etcd
 import (
 	"testing"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/integration"
 	"github.com/m3db/m3cluster/services"
 
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/integration"
 	"github.com/stretchr/testify/require"
 )
 
@@ -203,6 +203,9 @@ func TestCacheFileForZone(t *testing.T) {
 
 	kvOpts = cs.newkvOptions("z1", cs.cacheFileFn("f1", "", "f2"), "namespace")
 	require.Equal(t, "/cacheDir/namespace_test_app_z1_f1_f2.json", kvOpts.CacheFileFn()(kvOpts.Prefix()))
+
+	kvOpts = cs.newkvOptions("z1", cs.cacheFileFn("/r2/m3agg"), "")
+	require.Equal(t, "/cacheDir/test_app_z1__r2_m3agg.json", kvOpts.CacheFileFn()(kvOpts.Prefix()))
 }
 
 func TestValidateNamespace(t *testing.T) {

--- a/services/client/options.go
+++ b/services/client/options.go
@@ -84,12 +84,19 @@ type Options interface {
 	// SetInstrumentsOptions sets the InstrumentsOptions
 	SetInstrumentsOptions(iopts instrument.Options) Options
 
+	// NamespaceOptions is the custom namespaces.
+	NamespaceOptions() services.NamespaceOptions
+
+	// SetNamespaceOptions sets the NamespaceOptions.
+	SetNamespaceOptions(opts services.NamespaceOptions) Options
+
 	// Validate validates the Options
 	Validate() error
 }
 
 type options struct {
 	initTimeout time.Duration
+	nOpts       services.NamespaceOptions
 	kvGen       KVGen
 	hbGen       HeartbeatGen
 	ldGen       LeaderGen
@@ -100,6 +107,7 @@ type options struct {
 func NewOptions() Options {
 	return options{
 		iopts:       instrument.NewOptions(),
+		nOpts:       services.NewNamespaceOptions(),
 		initTimeout: defaultInitTimeout,
 	}
 }
@@ -166,5 +174,14 @@ func (o options) InstrumentsOptions() instrument.Options {
 
 func (o options) SetInstrumentsOptions(iopts instrument.Options) Options {
 	o.iopts = iopts
+	return o
+}
+
+func (o options) NamespaceOptions() services.NamespaceOptions {
+	return o.nOpts
+}
+
+func (o options) SetNamespaceOptions(opts services.NamespaceOptions) Options {
+	o.nOpts = opts
 	return o
 }

--- a/services/client/services_test.go
+++ b/services/client/services_test.go
@@ -504,12 +504,12 @@ func TestWatchIncludeUnhealthy(t *testing.T) {
 	require.True(t, ok)
 
 	// set a bad value for placement
-	v, err := kvm.kv.Set(placementKey(sid), &metadataproto.Metadata{Port: 1})
+	v, err := kvm.kv.Set(keyFnWithNamespace(placementPrefix)(sid), &metadataproto.Metadata{Port: 1})
 	require.NoError(t, err)
 	require.Equal(t, 3, v)
 
 	// make sure the newly set bad value has been propagated to watches
-	testWatch, err := kvm.kv.Watch(placementKey(sid))
+	testWatch, err := kvm.kv.Watch(keyFnWithNamespace(placementPrefix)(sid))
 	require.NoError(t, err)
 	for range testWatch.C() {
 		if testWatch.Get().Version() == 3 {
@@ -653,12 +653,12 @@ func TestWatchNotIncludeUnhealthy(t *testing.T) {
 	require.True(t, ok)
 
 	// set a bad value for placement
-	v, err := kvm.kv.Set(placementKey(sid), &metadataproto.Metadata{Port: 1})
+	v, err := kvm.kv.Set(keyFnWithNamespace(placementPrefix)(sid), &metadataproto.Metadata{Port: 1})
 	require.NoError(t, err)
 	require.Equal(t, 2, v)
 
 	// make sure the newly set bad value has been propagated to watches
-	testWatch, err := kvm.kv.Watch(placementKey(sid))
+	testWatch, err := kvm.kv.Watch(keyFnWithNamespace(placementPrefix)(sid))
 	require.NoError(t, err)
 	for range testWatch.C() {
 		if testWatch.Get().Version() == 2 {
@@ -752,6 +752,9 @@ func TestMultipleWatches(t *testing.T) {
 	require.NoError(t, err)
 
 	sd, err := NewServices(opts)
+	require.NoError(t, err)
+
+	_, err = sd.Query(sid, qopts)
 	require.NoError(t, err)
 
 	w1, err := sd.Watch(sid, qopts)

--- a/services/client/storage.go
+++ b/services/client/storage.go
@@ -27,7 +27,7 @@ import (
 	"github.com/m3db/m3cluster/services/placement"
 )
 
-func (s *client) Set(sid services.ServiceID, p services.Placement) error {
+func (c *client) Set(sid services.ServiceID, p services.Placement) error {
 	if err := validateServiceID(sid); err != nil {
 		return err
 	}
@@ -35,15 +35,15 @@ func (s *client) Set(sid services.ServiceID, p services.Placement) error {
 	if err != nil {
 		return err
 	}
-	kvm, err := s.getKVManager(sid.Zone())
+	kvm, err := c.getKVManager(sid.Zone())
 	if err != nil {
 		return err
 	}
-	_, err = kvm.kv.Set(placementKey(sid), &placementProto)
+	_, err = kvm.kv.Set(c.placementKeyFn(sid), &placementProto)
 	return err
 }
 
-func (s *client) CheckAndSet(sid services.ServiceID, p services.Placement, version int) error {
+func (c *client) CheckAndSet(sid services.ServiceID, p services.Placement, version int) error {
 	if err := validateServiceID(sid); err != nil {
 		return err
 	}
@@ -53,20 +53,20 @@ func (s *client) CheckAndSet(sid services.ServiceID, p services.Placement, versi
 		return err
 	}
 
-	kvm, err := s.getKVManager(sid.Zone())
+	kvm, err := c.getKVManager(sid.Zone())
 	if err != nil {
 		return err
 	}
 
 	_, err = kvm.kv.CheckAndSet(
-		placementKey(sid),
+		c.placementKeyFn(sid),
 		version,
 		&placementProto,
 	)
 	return err
 }
 
-func (s *client) SetIfNotExist(sid services.ServiceID, p services.Placement) error {
+func (c *client) SetIfNotExist(sid services.ServiceID, p services.Placement) error {
 	if err := validateServiceID(sid); err != nil {
 		return err
 	}
@@ -76,38 +76,38 @@ func (s *client) SetIfNotExist(sid services.ServiceID, p services.Placement) err
 		return err
 	}
 
-	kvm, err := s.getKVManager(sid.Zone())
+	kvm, err := c.getKVManager(sid.Zone())
 	if err != nil {
 		return err
 	}
 
 	_, err = kvm.kv.SetIfNotExists(
-		placementKey(sid),
+		c.placementKeyFn(sid),
 		&placementProto,
 	)
 	return err
 }
 
-func (s *client) Delete(sid services.ServiceID) error {
+func (c *client) Delete(sid services.ServiceID) error {
 	if err := validateServiceID(sid); err != nil {
 		return err
 	}
 
-	kvm, err := s.getKVManager(sid.Zone())
+	kvm, err := c.getKVManager(sid.Zone())
 	if err != nil {
 		return err
 	}
 
-	_, err = kvm.kv.Delete(placementKey(sid))
+	_, err = kvm.kv.Delete(c.placementKeyFn(sid))
 	return err
 }
 
-func (s *client) Placement(sid services.ServiceID) (services.Placement, int, error) {
+func (c *client) Placement(sid services.ServiceID) (services.Placement, int, error) {
 	if err := validateServiceID(sid); err != nil {
 		return nil, 0, err
 	}
 
-	v, err := s.getPlacementValue(sid)
+	v, err := c.getPlacementValue(sid)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/services/client/storage_test.go
+++ b/services/client/storage_test.go
@@ -104,6 +104,37 @@ func TestPlacementStorage(t *testing.T) {
 	require.Equal(t, kv.ErrNotFound, err)
 }
 
+func TestPlacementNamespaceOverride(t *testing.T) {
+	opts, closer, _ := testSetup(t)
+	defer closer()
+
+	ps, err := newPlacementStorage(opts.SetNamespaceOptions(
+		services.NewNamespaceOptions().SetPlacementNamespace("test_ns"),
+	))
+	require.NoError(t, err)
+
+	sid := services.NewServiceID().SetName("m3db")
+
+	p := placement.NewPlacement().
+		SetInstances([]services.PlacementInstance{}).
+		SetShards([]uint32{}).
+		SetReplicaFactor(0)
+
+	err = ps.Set(sid, p)
+	require.NoError(t, err)
+
+	newP, v, err := ps.Placement(sid)
+	require.NoError(t, err)
+	require.Equal(t, 1, v)
+	require.Equal(t, newP, p.SetVersion(v))
+
+	ps2, err := newPlacementStorage(opts)
+	require.NoError(t, err)
+
+	_, _, err = ps2.Placement(sid)
+	require.Error(t, err)
+}
+
 // newPlacementStorage returns a client of placement.Storage
 func newPlacementStorage(opts Options) (placement.Storage, error) {
 	if opts.KVGen() == nil {
@@ -111,7 +142,9 @@ func newPlacementStorage(opts Options) (placement.Storage, error) {
 	}
 
 	return &client{
-		kvManagers: map[string]*kvManager{},
-		opts:       opts,
+		opts:           opts,
+		placementKeyFn: keyFnWithNamespace(placementNamespace(opts.NamespaceOptions().PlacementNamespace())),
+		metadataKeyFn:  keyFnWithNamespace(metadataNamespace(opts.NamespaceOptions().MetadataNamespace())),
+		kvManagers:     map[string]*kvManager{},
 	}, nil
 }

--- a/services/client/util.go
+++ b/services/client/util.go
@@ -32,16 +32,32 @@ const (
 	keyFormat       = "%s/%s"
 )
 
+type keyFn func(sid services.ServiceID) string
+
+func placementNamespace(ns string) string {
+	if ns == "" {
+		ns = placementPrefix
+	}
+
+	return ns
+}
+
+func metadataNamespace(ns string) string {
+	if ns == "" {
+		ns = metadataPrefix
+	}
+
+	return ns
+}
+
+func keyFnWithNamespace(namespace string) keyFn {
+	return func(sid services.ServiceID) string {
+		return fmt.Sprintf(keyFormat, namespace, serviceKey(sid))
+	}
+}
+
 func adKey(sid services.ServiceID, id string) string {
 	return fmt.Sprintf(keyFormat, serviceKey(sid), id)
-}
-
-func placementKey(s services.ServiceID) string {
-	return fmt.Sprintf(keyFormat, placementPrefix, serviceKey(s))
-}
-
-func metadataKey(s services.ServiceID) string {
-	return fmt.Sprintf(keyFormat, metadataPrefix, serviceKey(s))
 }
 
 func serviceKey(s services.ServiceID) string {

--- a/services/client/util_test.go
+++ b/services/client/util_test.go
@@ -30,7 +30,8 @@ import (
 func TestKeys(t *testing.T) {
 	sid := services.NewServiceID().SetName("m3db").SetEnvironment("production")
 	assert.Equal(t, "production/m3db", serviceKey(sid))
-	assert.Equal(t, "_sd.placement/production/m3db", placementKey(sid))
-	assert.Equal(t, "_sd.metadata/production/m3db", metadataKey(sid))
+	assert.Equal(t, "_sd.placement/production/m3db", keyFnWithNamespace(placementPrefix)(sid))
+	assert.Equal(t, "_sd.metadata/production/m3db", keyFnWithNamespace(metadataPrefix)(sid))
+	assert.Equal(t, "testns/production/m3db", keyFnWithNamespace("testns")(sid))
 	assert.Equal(t, "production/m3db/instance1", adKey(sid, "instance1"))
 }

--- a/services/config.go
+++ b/services/config.go
@@ -22,24 +22,24 @@ package services
 
 // Configuration configs the Options.
 type Configuration struct {
-	NamespaceOverride NamespaceConfiguration `yaml:"namespaceOverride"`
+	Namespaces NamespacesConfiguration `yaml:"namespaces"`
 }
 
 // NewOptions creates a new Options.
 func (cfg Configuration) NewOptions() Options {
 	return NewOptions().
-		SetNamespaceOptions(cfg.NamespaceOverride.NewOptions())
+		SetNamespaceOptions(cfg.Namespaces.NewOptions())
 }
 
-// NamespaceConfiguration configs the NamespaceOptions.
-type NamespaceConfiguration struct {
-	PlacementNamespace string `yaml:"placementNamespace"`
-	MetadataNamespace  string `yaml:"metadataNamespace"`
+// NamespacesConfiguration configs the NamespaceOptions.
+type NamespacesConfiguration struct {
+	Placement string `yaml:"placement"`
+	Metadata  string `yaml:"metadata"`
 }
 
 // NewOptions creates a new NamespaceOptions.
-func (cfg NamespaceConfiguration) NewOptions() NamespaceOptions {
+func (cfg NamespacesConfiguration) NewOptions() NamespaceOptions {
 	return NewNamespaceOptions().
-		SetPlacementNamespace(cfg.PlacementNamespace).
-		SetMetadataNamespace(cfg.MetadataNamespace)
+		SetPlacementNamespace(cfg.Placement).
+		SetMetadataNamespace(cfg.Metadata)
 }

--- a/services/config.go
+++ b/services/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,33 +18,28 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package client
+package services
 
-import (
-	"github.com/m3db/m3cluster/kv"
-	"github.com/m3db/m3cluster/services"
-)
+// Configuration configs the Options.
+type Configuration struct {
+	NamespaceOverride NamespaceConfiguration `yaml:"namespaceOverride"`
+}
 
-// Client is the base interface into the cluster management system, providing
-// access to cluster services.
-type Client interface {
-	// Services returns access to the set of services.
-	Services() (services.Services, error)
+// NewOptions creates a new Options.
+func (cfg Configuration) NewOptions() Options {
+	return NewOptions().
+		SetNamespaceOptions(cfg.NamespaceOverride.NewOptions())
+}
 
-	// ServiceDiscovery returns service discovery with custom namespaces.
-	ServiceDiscovery(opts services.Options) (services.Services, error)
+// NamespaceConfiguration configs the NamespaceOptions.
+type NamespaceConfiguration struct {
+	PlacementNamespace string `yaml:"placementNamespace"`
+	MetadataNamespace  string `yaml:"metadataNamespace"`
+}
 
-	// KV returns access to the distributed configuration store.
-	// To be deprecated.
-	KV() (kv.Store, error)
-
-	// Txn returns access to the transaction store.
-	// To be deprecated.
-	Txn() (kv.TxnStore, error)
-
-	// Store returns access to the distributed configuration store with a namespace.
-	Store(namespace string) (kv.Store, error)
-
-	// TxnStore returns access to the transaction store with a namespace.
-	TxnStore(namespace string) (kv.TxnStore, error)
+// NewOptions creates a new NamespaceOptions.
+func (cfg NamespaceConfiguration) NewOptions() NamespaceOptions {
+	return NewNamespaceOptions().
+		SetPlacementNamespace(cfg.PlacementNamespace).
+		SetMetadataNamespace(cfg.MetadataNamespace)
 }

--- a/services/config_test.go
+++ b/services/config_test.go
@@ -23,16 +23,15 @@ package services
 import (
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestConfiguration(t *testing.T) {
 	configStr := `
-namespaceOverride:
-  placementNamespace: p
-  metadataNamespace: m
+namespaces:
+  placement: p
+  metadata: m
 `
 
 	var cfg Configuration
@@ -45,11 +44,11 @@ namespaceOverride:
 
 func TestNamespaceConfiguration(t *testing.T) {
 	configStr := `
-placementNamespace: p
-metadataNamespace: m
+placement: p
+metadata: m
 `
 
-	var cfg NamespaceConfiguration
+	var cfg NamespacesConfiguration
 	err := yaml.Unmarshal([]byte(configStr), &cfg)
 	require.NoError(t, err)
 	opts := cfg.NewOptions()

--- a/services/config_test.go
+++ b/services/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,33 +18,41 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package client
+package services
 
 import (
-	"github.com/m3db/m3cluster/kv"
-	"github.com/m3db/m3cluster/services"
+	"testing"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/stretchr/testify/require"
 )
 
-// Client is the base interface into the cluster management system, providing
-// access to cluster services.
-type Client interface {
-	// Services returns access to the set of services.
-	Services() (services.Services, error)
+func TestConfiguration(t *testing.T) {
+	configStr := `
+namespaceOverride:
+  placementNamespace: p
+  metadataNamespace: m
+`
 
-	// ServiceDiscovery returns service discovery with custom namespaces.
-	ServiceDiscovery(opts services.Options) (services.Services, error)
+	var cfg Configuration
+	err := yaml.Unmarshal([]byte(configStr), &cfg)
+	require.NoError(t, err)
+	opts := cfg.NewOptions()
+	require.Equal(t, "p", opts.NamespaceOptions().PlacementNamespace())
+	require.Equal(t, "m", opts.NamespaceOptions().MetadataNamespace())
+}
 
-	// KV returns access to the distributed configuration store.
-	// To be deprecated.
-	KV() (kv.Store, error)
+func TestNamespaceConfiguration(t *testing.T) {
+	configStr := `
+placementNamespace: p
+metadataNamespace: m
+`
 
-	// Txn returns access to the transaction store.
-	// To be deprecated.
-	Txn() (kv.TxnStore, error)
-
-	// Store returns access to the distributed configuration store with a namespace.
-	Store(namespace string) (kv.Store, error)
-
-	// TxnStore returns access to the transaction store with a namespace.
-	TxnStore(namespace string) (kv.TxnStore, error)
+	var cfg NamespaceConfiguration
+	err := yaml.Unmarshal([]byte(configStr), &cfg)
+	require.NoError(t, err)
+	opts := cfg.NewOptions()
+	require.Equal(t, "p", opts.PlacementNamespace())
+	require.Equal(t, "m", opts.MetadataNamespace())
 }

--- a/services/services.go
+++ b/services/services.go
@@ -330,3 +330,51 @@ func (c campaignOpts) SetLeaderValue(v string) CampaignOptions {
 	c.val = v
 	return c
 }
+
+type options struct {
+	namespaceOpts NamespaceOptions
+}
+
+// NewOptions constructs a new Options.
+func NewOptions() Options {
+	return &options{
+		namespaceOpts: NewNamespaceOptions(),
+	}
+}
+
+func (o options) NamespaceOptions() NamespaceOptions {
+	return o.namespaceOpts
+}
+
+func (o options) SetNamespaceOptions(opts NamespaceOptions) Options {
+	o.namespaceOpts = opts
+	return o
+}
+
+type namespaceOpts struct {
+	placementNamespace string
+	metadataNamespace  string
+}
+
+// NewNamespaceOptions constructs a new NamespaceOptions.
+func NewNamespaceOptions() NamespaceOptions {
+	return &namespaceOpts{}
+}
+
+func (opts namespaceOpts) PlacementNamespace() string {
+	return opts.placementNamespace
+}
+
+func (opts namespaceOpts) SetPlacementNamespace(v string) NamespaceOptions {
+	opts.placementNamespace = v
+	return opts
+}
+
+func (opts namespaceOpts) MetadataNamespace() string {
+	return opts.metadataNamespace
+}
+
+func (opts namespaceOpts) SetMetadataNamespace(v string) NamespaceOptions {
+	opts.metadataNamespace = v
+	return opts
+}

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -28,6 +28,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestOptions(t *testing.T) {
+	opts := NewOptions()
+	assert.Equal(t, NewNamespaceOptions(), opts.NamespaceOptions())
+
+	nOpts := NewNamespaceOptions().SetPlacementNamespace("p")
+	opts = opts.SetNamespaceOptions(nOpts)
+	assert.Equal(t, nOpts, opts.NamespaceOptions())
+}
+
+func TestNamespaceOptions(t *testing.T) {
+	opts := NewNamespaceOptions()
+	assert.Empty(t, opts.PlacementNamespace())
+	assert.Empty(t, opts.MetadataNamespace())
+
+	opts = opts.SetPlacementNamespace("p").SetMetadataNamespace("m")
+	assert.Equal(t, "p", opts.PlacementNamespace())
+	assert.Equal(t, "m", opts.MetadataNamespace())
+}
+
 func TestConvertBetweenProtoAndService(t *testing.T) {
 	protoShards := getProtoShards([]uint32{0, 1, 2})
 	sid := NewServiceID().

--- a/services/types.go
+++ b/services/types.go
@@ -31,6 +31,31 @@ import (
 	xwatch "github.com/m3db/m3x/watch"
 )
 
+// Options are options to configure the service discovery service.
+type Options interface {
+	// NamespaceOptions is the namespace options.
+	NamespaceOptions() NamespaceOptions
+
+	// SetNamespaceOptions sets namespace options.
+	SetNamespaceOptions(opts NamespaceOptions) Options
+}
+
+// NamespaceOptions are options to provide custom namespaces in service discovery service.
+// TODO(cw): Provide overrides for leader service and heartbeat service.
+type NamespaceOptions interface {
+	// PlacementNamespace is the custom namespace for placement.
+	PlacementNamespace() string
+
+	// SetPlacementNamespace sets the custom namespace for placement.
+	SetPlacementNamespace(v string) NamespaceOptions
+
+	// MetadataNamespace is the custom namespace for metadata.
+	MetadataNamespace() string
+
+	// SetMetadataNamespace sets the custom namespace for metadata.
+	SetMetadataNamespace(v string) NamespaceOptions
+}
+
 // Services provides access to the service topology
 type Services interface {
 	// Advertise advertises the availability of an instance of a service


### PR DESCRIPTION
Right now by default the placement data and metadata data in service discovery service are stored under _sd.placement and _sd.metadata namespace. This pr adds a new method to allow users to provide custom namespace to override those namespaces. So that we could support the r2 placement being accessible from both ServiceDiscovery interface and kv.Store interface although the value is stored in a custom namespace on etcd.

For example if a namespace of "/test_placement" was provided, the placement data for service: "statsdex_m3dbnode" could be accessible under "/test_placement/[env]/statsdex_m3dbnode".

In the future we could allow overriding the default namespace for leader service and heartbeat service as well.

@xichen2020 @prateek @jeromefroe @schallert @dgromov 