### PR TITLE
Embed placement.Storage in placement.Service

### DIFF
--- a/placement/placement_mock.go
+++ b/placement/placement_mock.go
@@ -1256,6 +1256,80 @@ func (_m *MockService) EXPECT() *_MockServiceRecorder {
 	return _m.recorder
 }
 
+func (_m *MockService) SetPlacementProto(p proto.Message) error {
+	ret := _m.ctrl.Call(_m, "SetPlacementProto", p)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockServiceRecorder) SetPlacementProto(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetPlacementProto", arg0)
+}
+
+func (_m *MockService) PlacementProto() (proto.Message, int, error) {
+	ret := _m.ctrl.Call(_m, "PlacementProto")
+	ret0, _ := ret[0].(proto.Message)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockServiceRecorder) PlacementProto() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PlacementProto")
+}
+
+func (_m *MockService) Set(p Placement) error {
+	ret := _m.ctrl.Call(_m, "Set", p)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockServiceRecorder) Set(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Set", arg0)
+}
+
+func (_m *MockService) CheckAndSet(p Placement, version int) error {
+	ret := _m.ctrl.Call(_m, "CheckAndSet", p, version)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockServiceRecorder) CheckAndSet(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckAndSet", arg0, arg1)
+}
+
+func (_m *MockService) SetIfNotExist(p Placement) error {
+	ret := _m.ctrl.Call(_m, "SetIfNotExist", p)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockServiceRecorder) SetIfNotExist(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIfNotExist", arg0)
+}
+
+func (_m *MockService) Delete() error {
+	ret := _m.ctrl.Call(_m, "Delete")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockServiceRecorder) Delete() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete")
+}
+
+func (_m *MockService) Placement() (Placement, int, error) {
+	ret := _m.ctrl.Call(_m, "Placement")
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockServiceRecorder) Placement() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Placement")
+}
+
 func (_m *MockService) BuildInitialPlacement(instances []Instance, numShards int, rf int) (Placement, error) {
 	ret := _m.ctrl.Call(_m, "BuildInitialPlacement", instances, numShards, rf)
 	ret0, _ := ret[0].(Placement)
@@ -1331,38 +1405,6 @@ func (_m *MockService) MarkInstanceAvailable(instanceID string) error {
 
 func (_mr *_MockServiceRecorder) MarkInstanceAvailable(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MarkInstanceAvailable", arg0)
-}
-
-func (_m *MockService) Delete() error {
-	ret := _m.ctrl.Call(_m, "Delete")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockServiceRecorder) Delete() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete")
-}
-
-func (_m *MockService) SetPlacement(p Placement) error {
-	ret := _m.ctrl.Call(_m, "SetPlacement", p)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockServiceRecorder) SetPlacement(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetPlacement", arg0)
-}
-
-func (_m *MockService) Placement() (Placement, int, error) {
-	ret := _m.ctrl.Call(_m, "Placement")
-	ret0, _ := ret[0].(Placement)
-	ret1, _ := ret[1].(int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-func (_mr *_MockServiceRecorder) Placement() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Placement")
 }
 
 // Mock of Algorithm interface

--- a/placement/service/service.go
+++ b/placement/service/service.go
@@ -32,6 +32,7 @@ import (
 
 type placementService struct {
 	placement.Storage
+
 	opts     placement.Options
 	algo     placement.Algorithm
 	selector placement.InstanceSelector
@@ -88,11 +89,11 @@ func (ps *placementService) BuildInitialPlacement(
 		return nil, err
 	}
 
-	return p, ps.Storage.SetIfNotExist(p)
+	return p, ps.SetIfNotExist(p)
 }
 
 func (ps *placementService) AddReplica() (placement.Placement, error) {
-	p, v, err := ps.Storage.Placement()
+	p, v, err := ps.Placement()
 	if err != nil {
 		return nil, err
 	}
@@ -105,13 +106,13 @@ func (ps *placementService) AddReplica() (placement.Placement, error) {
 		return nil, err
 	}
 
-	return p, ps.Storage.CheckAndSet(p, v)
+	return p, ps.CheckAndSet(p, v)
 }
 
 func (ps *placementService) AddInstances(
 	candidates []placement.Instance,
 ) (placement.Placement, []placement.Instance, error) {
-	p, v, err := ps.Storage.Placement()
+	p, v, err := ps.Placement()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -137,11 +138,11 @@ func (ps *placementService) AddInstances(
 		addingInstances[i] = addingInstance
 	}
 
-	return p, addingInstances, ps.Storage.CheckAndSet(p, v)
+	return p, addingInstances, ps.CheckAndSet(p, v)
 }
 
 func (ps *placementService) RemoveInstances(instanceIDs []string) (placement.Placement, error) {
-	p, v, err := ps.Storage.Placement()
+	p, v, err := ps.Placement()
 	if err != nil {
 		return nil, err
 	}
@@ -154,14 +155,14 @@ func (ps *placementService) RemoveInstances(instanceIDs []string) (placement.Pla
 		return nil, err
 	}
 
-	return p, ps.Storage.CheckAndSet(p, v)
+	return p, ps.CheckAndSet(p, v)
 }
 
 func (ps *placementService) ReplaceInstances(
 	leavingInstanceIDs []string,
 	candidates []placement.Instance,
 ) (placement.Placement, []placement.Instance, error) {
-	p, v, err := ps.Storage.Placement()
+	p, v, err := ps.Placement()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -188,11 +189,11 @@ func (ps *placementService) ReplaceInstances(
 		addedInstances = append(addedInstances, addedInstance)
 	}
 
-	return p, addedInstances, ps.Storage.CheckAndSet(p, v)
+	return p, addedInstances, ps.CheckAndSet(p, v)
 }
 
 func (ps *placementService) MarkShardAvailable(instanceID string, shardID uint32) error {
-	p, v, err := ps.Storage.Placement()
+	p, v, err := ps.Placement()
 	if err != nil {
 		return err
 	}
@@ -206,11 +207,11 @@ func (ps *placementService) MarkShardAvailable(instanceID string, shardID uint32
 		return err
 	}
 
-	return ps.Storage.CheckAndSet(p, v)
+	return ps.CheckAndSet(p, v)
 }
 
 func (ps *placementService) MarkInstanceAvailable(instanceID string) error {
-	p, v, err := ps.Storage.Placement()
+	p, v, err := ps.Placement()
 	if err != nil {
 		return err
 	}
@@ -233,5 +234,5 @@ func (ps *placementService) MarkInstanceAvailable(instanceID string) error {
 		return err
 	}
 
-	return ps.Storage.CheckAndSet(p, v)
+	return ps.CheckAndSet(p, v)
 }

--- a/placement/types.go
+++ b/placement/types.go
@@ -391,6 +391,8 @@ type Storage interface {
 // Service handles the placement related operations for registered services
 // all write or update operations will persist the generated placement before returning success.
 type Service interface {
+	Storage
+
 	// BuildInitialPlacement initialize a placement.
 	BuildInitialPlacement(instances []Instance, numShards int, rf int) (Placement, error)
 
@@ -418,15 +420,6 @@ type Service interface {
 
 	// MarkInstanceAvailable marks all the shards on a given instance as available.
 	MarkInstanceAvailable(instanceID string) error
-
-	// Delete deletes the placement.
-	Delete() error
-
-	// SetPlacement writes a placement.
-	SetPlacement(p Placement) error
-
-	// Placement reads placement and version.
-	Placement() (Placement, int, error)
 }
 
 // Algorithm places shards on instances.

--- a/services/client/etcd/services.go
+++ b/services/client/etcd/services.go
@@ -125,25 +125,15 @@ func (c *client) PlacementService(sid services.ServiceID, opts placement.Options
 		return nil, err
 	}
 
-	ps, err := c.PlacementStorage(sid, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return service.NewPlacementService(ps, opts), nil
-}
-
-func (c *client) PlacementStorage(sid services.ServiceID, opts placement.Options) (placement.Storage, error) {
-	if err := validateServiceID(sid); err != nil {
-		return nil, err
-	}
-
 	store, err := c.opts.KVGen()(sid.Zone())
 	if err != nil {
 		return nil, err
 	}
 
-	return storage.NewPlacementStorage(store, c.placementKeyFn(sid), opts), nil
+	return service.NewPlacementService(
+		storage.NewPlacementStorage(store, c.placementKeyFn(sid), opts),
+		opts,
+	), nil
 }
 
 func (c *client) Advertise(ad services.Advertisement) error {

--- a/services/services_mock.go
+++ b/services/services_mock.go
@@ -230,17 +230,6 @@ func (_mr *_MockServicesRecorder) PlacementService(arg0, arg1 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PlacementService", arg0, arg1)
 }
 
-func (_m *MockServices) PlacementStorage(sid ServiceID, popts placement.Options) (placement.Storage, error) {
-	ret := _m.ctrl.Call(_m, "PlacementStorage", sid, popts)
-	ret0, _ := ret[0].(placement.Storage)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockServicesRecorder) PlacementStorage(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PlacementStorage", arg0, arg1)
-}
-
 func (_m *MockServices) HeartbeatService(service ServiceID) (HeartbeatService, error) {
 	ret := _m.ctrl.Call(_m, "HeartbeatService", service)
 	ret0, _ := ret[0].(HeartbeatService)

--- a/services/types.go
+++ b/services/types.go
@@ -78,9 +78,6 @@ type Services interface {
 	// PlacementService returns a client of placement.Service
 	PlacementService(sid ServiceID, popts placement.Options) (placement.Service, error)
 
-	// PlacementStorage returns a client of placement.Storage.
-	PlacementStorage(sid ServiceID, popts placement.Options) (placement.Storage, error)
-
 	// HeartbeatService returns a heartbeat store for the given service.
 	HeartbeatService(service ServiceID) (HeartbeatService, error)
 


### PR DESCRIPTION
placement.Service used to expose Delete(), SetPlacement and Placement(), which are also exposed from placement.Storage interface, now that we also need to expose SetProto() and Proto(), this pr made placement.Storage embedded in placement.Service interface so that future updates in the placement.Storage interface are available through placement.Service as well.

this pr also moved Dryrun logic to placement.Storage.

@xichen2020 @prateek @jeromefroe 