### PR TITLE
Mirror placement algo changes

### DIFF
--- a/placement/algo/mirrored.go
+++ b/placement/algo/mirrored.go
@@ -91,18 +91,18 @@ func (a mirroredAlgorithm) RemoveInstances(
 		return nil, err
 	}
 
-	removingInstances := make([]placement.Instance, len(instanceIDs))
-	for i, id := range instanceIDs {
-		instance, ok := p.Instance(id)
-		if !ok {
-			return nil, fmt.Errorf("instance %s not found in placement", id)
-		}
-		removingInstances[i] = instance
-	}
-
 	p, err := placement.MarkAllShardsAsAvailable(p)
 	if err != nil {
 		return nil, err
+	}
+
+	removingInstances := make([]placement.Instance, 0, len(instanceIDs))
+	for _, id := range instanceIDs {
+		instance, ok := p.Instance(id)
+		if !ok {
+			return nil, fmt.Errorf("instance %s does not exist in the placement", id)
+		}
+		removingInstances = append(removingInstances, instance)
 	}
 
 	mirrorPlacement, err := mirrorFromPlacement(p)
@@ -121,7 +121,7 @@ func (a mirroredAlgorithm) RemoveInstances(
 			return nil, err
 		}
 		// Place the shards from the leaving instance to the rest of the cluster
-		if err := ph.PlaceShards(leavingInstance.Shards().All(), leavingInstance, nonLeavingInstances(ph.Instances())); err != nil {
+		if err := ph.PlaceShards(leavingInstance.Shards().All(), leavingInstance, ph.Instances()); err != nil {
 			return nil, err
 		}
 
@@ -146,9 +146,14 @@ func (a mirroredAlgorithm) AddInstances(
 	}
 
 	// At this point, all leaving instances in the placement are cleaned up.
-	for _, instance := range addingInstances {
+	for i, instance := range addingInstances {
 		if _, exist := p.Instance(instance.ID()); exist {
 			return nil, fmt.Errorf("instance %s already exist in the placement", instance.ID())
+		}
+		if placement.IsInstanceLeaving(instance) {
+			// The instance was leaving in placement, after MarkAllShardsAsAvailable it is now removed
+			// from the placement, so we should treat them as fresh new instances.
+			addingInstances[i] = instance.SetShards(shard.NewShards(nil))
 		}
 	}
 
@@ -192,6 +197,18 @@ func (a mirroredAlgorithm) ReplaceInstances(
 		return nil, err
 	}
 
+	// At this point, all leaving instances in the placement are cleaned up.
+	for i, instance := range addingInstances {
+		if _, exist := p.Instance(instance.ID()); exist {
+			return nil, fmt.Errorf("instance %s already exist in the placement", instance.ID())
+		}
+		if placement.IsInstanceLeaving(instance) {
+			// The instance was leaving in placement, after MarkAllShardsAsAvailable it is now removed
+			// from the placement, so we should treat them as fresh new instances.
+			addingInstances[i] = instance.SetShards(shard.NewShards(nil))
+		}
+	}
+
 	for i := range leavingInstanceIDs {
 		// We want full replacement for each instance.
 		p, err = a.shardedAlgo.ReplaceInstances(p, leavingInstanceIDs[i:i+1], addingInstances[i:i+1])
@@ -211,15 +228,18 @@ func groupInstancesByShardSetID(
 		res         = make([]placement.Instance, 0, len(instances))
 	)
 	for _, instance := range instances {
-		ssID := instance.ShardSetID()
-		weight := instance.Weight()
-		rack := instance.Rack()
+		var (
+			ssID   = instance.ShardSetID()
+			weight = instance.Weight()
+			rack   = instance.Rack()
+			shards = instance.Shards()
+		)
 		meta, ok := shardSetMap[ssID]
 		if !ok {
 			meta = &shardSetMetadata{
 				weight: weight,
 				racks:  make(map[string]struct{}, rf),
-				shards: instance.Shards(),
+				shards: shards,
 			}
 			shardSetMap[ssID] = meta
 		}
@@ -229,6 +249,10 @@ func groupInstancesByShardSetID(
 
 		if meta.weight != weight {
 			return nil, fmt.Errorf("found different weights: %d and %d, for shardset id %d", meta.weight, weight, ssID)
+		}
+
+		if !meta.shards.Equals(shards) {
+			return nil, fmt.Errorf("found different shards: %v and %v, for shardset id %d", meta.shards, shards, ssID)
 		}
 
 		meta.racks[rack] = struct{}{}
@@ -269,6 +293,7 @@ func mirrorFromPlacement(p placement.Placement) (placement.Placement, error) {
 		SetInstances(mirrorInstances).
 		SetReplicaFactor(1).
 		SetShards(p.Shards()).
+		SetCutoverNanos(p.CutoverNanos()).
 		SetIsSharded(true).
 		SetIsMirrored(true), nil
 }
@@ -306,6 +331,7 @@ func placementFromMirror(
 		SetInstances(instancesWithShards).
 		SetReplicaFactor(rf).
 		SetShards(mirror.Shards()).
+		SetCutoverNanos(mirror.CutoverNanos()).
 		SetIsMirrored(true).
 		SetIsSharded(true), nil
 }
@@ -324,7 +350,8 @@ func instancesFromMirror(
 	for i, instance := range instances {
 		newShards := make([]shard.Shard, shards.NumShards())
 		for j, s := range shards.All() {
-			newShard := shard.NewShard(s.ID()).SetState(s.State())
+			// TODO move clone() to shard interface
+			newShard := shard.NewShard(s.ID()).SetState(s.State()).SetCutoffNanos(s.CutoffNanos()).SetCutoverNanos(s.CutoverNanos())
 			sourceID := s.SourceID()
 			if sourceID != "" {
 				// The sourceID in the mirror placement is shardSetID, need to be converted

--- a/placement/algo/sharded.go
+++ b/placement/algo/sharded.go
@@ -102,7 +102,7 @@ func (a rackAwarePlacementAlgorithm) RemoveInstances(
 			return nil, err
 		}
 		// place the shards from the leaving instance to the rest of the cluster
-		if err := ph.PlaceShards(leavingInstance.Shards().All(), leavingInstance, nonLeavingInstances(ph.Instances())); err != nil {
+		if err := ph.PlaceShards(leavingInstance.Shards().All(), leavingInstance, ph.Instances()); err != nil {
 			return nil, err
 		}
 
@@ -177,7 +177,7 @@ func (a rackAwarePlacementAlgorithm) ReplaceInstances(
 	if a.opts.AllowPartialReplace() {
 		// Place the shards left on the leaving instance to the rest of the cluster.
 		for _, leavingInstance := range leavingInstances {
-			if err = ph.PlaceShards(leavingInstance.Shards().All(), leavingInstance, nonLeavingInstances(ph.Instances())); err != nil {
+			if err = ph.PlaceShards(leavingInstance.Shards().All(), leavingInstance, ph.Instances()); err != nil {
 				return nil, err
 			}
 		}

--- a/placement/algo/sharded_helper.go
+++ b/placement/algo/sharded_helper.go
@@ -361,7 +361,7 @@ func (ph *placementHelper) PlaceShards(
 		}
 	}
 
-	instanceHeap, err := ph.buildInstanceHeap(candidates, true)
+	instanceHeap, err := ph.buildInstanceHeap(nonLeavingInstances(candidates), true)
 	if err != nil {
 		return err
 	}
@@ -411,7 +411,7 @@ func (ph *placementHelper) returnInitializingShardsToSource(
 		}
 		sourceInstance, ok := candidateMap[sourceID]
 		if !ok {
-			return fmt.Errorf("could not find sourceID %s in the placement", sourceID)
+			return fmt.Errorf("could not find sourceID %s for instance %s, shard %d", sourceID, from.ID(), s.ID())
 		}
 		if placement.IsInstanceLeaving(sourceInstance) {
 			continue

--- a/placement/algo/sharded_test.go
+++ b/placement/algo/sharded_test.go
@@ -628,6 +628,44 @@ func TestLooseRackCheckAlgorithm(t *testing.T) {
 	assert.NoError(t, placement.Validate(p))
 }
 
+func TestRemoveMultipleInstances(t *testing.T) {
+	i1 := placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 10)
+	i2 := placement.NewEmptyInstance("i2", "r1", "z1", "endpoint", 10)
+	i3 := placement.NewEmptyInstance("i3", "r2", "z1", "endpoint", 20)
+	i4 := placement.NewEmptyInstance("i4", "r3", "z1", "endpoint", 10)
+	i5 := placement.NewEmptyInstance("i5", "r4", "z1", "endpoint", 30)
+	i6 := placement.NewEmptyInstance("i6", "r6", "z1", "endpoint", 40)
+	i7 := placement.NewEmptyInstance("i7", "r7", "z1", "endpoint", 10)
+	i8 := placement.NewEmptyInstance("i8", "r8", "z1", "endpoint", 10)
+	i9 := placement.NewEmptyInstance("i9", "r9", "z1", "endpoint", 10)
+
+	instances := []placement.Instance{i1, i2, i3, i4, i5, i6, i7, i8, i9}
+
+	ids := make([]uint32, 1024)
+	for i := 0; i < len(ids); i++ {
+		ids[i] = uint32(i)
+	}
+
+	a := newShardedAlgorithm(placement.NewOptions())
+	p, err := a.InitialPlacement(instances, ids, 2)
+	assert.NoError(t, err)
+	p = markAllShardsAsAvailable(t, p)
+
+	p, err = a.RemoveInstances(p, []string{"i1", "i2", "i3"})
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
+
+	i1, ok := p.Instance("i1")
+	assert.True(t, ok)
+	assert.True(t, placement.IsInstanceLeaving(i1))
+	i2, ok = p.Instance("i2")
+	assert.True(t, ok)
+	assert.True(t, placement.IsInstanceLeaving(i2))
+	i3, ok = p.Instance("i3")
+	assert.True(t, ok)
+	assert.True(t, placement.IsInstanceLeaving(i3))
+}
+
 func TestRemoveAbsentInstance(t *testing.T) {
 	i1 := placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1)
 

--- a/placement/selector/common.go
+++ b/placement/selector/common.go
@@ -38,10 +38,10 @@ func getValidCandidates(
 	opts placement.Options,
 ) ([]placement.Instance, error) {
 	var instances = make([]placement.Instance, 0, len(candidates))
-	for _, h := range candidates {
-		instanceInPlacement, exist := p.Instance(h.ID())
+	for _, instance := range candidates {
+		instanceInPlacement, exist := p.Instance(instance.ID())
 		if !exist {
-			instances = append(instances, h)
+			instances = append(instances, instance)
 			continue
 		}
 		if placement.IsInstanceLeaving(instanceInPlacement) {

--- a/placement/selector/mirrored.go
+++ b/placement/selector/mirrored.go
@@ -186,6 +186,9 @@ func (f *mirroredFilter) SelectReplaceInstances(
 		if instance.Hostname() == h.name {
 			continue
 		}
+		if placement.IsInstanceLeaving(instance) {
+			continue
+		}
 
 		conflictRacks[instance.Rack()] = struct{}{}
 	}

--- a/shard/shard.go
+++ b/shard/shard.go
@@ -138,27 +138,11 @@ func (s *shard) SetCutoffNanos(value int64) Shard {
 }
 
 func (s *shard) Equals(other Shard) bool {
-	if s.ID() != other.ID() {
-		return false
-	}
-
-	if s.State() != other.State() {
-		return false
-	}
-
-	if s.SourceID() != other.SourceID() {
-		return false
-	}
-
-	if s.CutoverNanos() != other.CutoverNanos() {
-		return false
-	}
-
-	if s.CutoffNanos() != other.CutoffNanos() {
-		return false
-	}
-
-	return true
+	return s.ID() == other.ID() &&
+		s.State() == other.State() &&
+		s.SourceID() == other.SourceID() &&
+		s.CutoverNanos() == other.CutoverNanos() &&
+		s.CutoffNanos() == other.CutoffNanos()
 }
 
 func (s *shard) Proto() (*placementpb.Shard, error) {

--- a/shard/shard.go
+++ b/shard/shard.go
@@ -137,6 +137,30 @@ func (s *shard) SetCutoffNanos(value int64) Shard {
 	return s
 }
 
+func (s *shard) Equals(other Shard) bool {
+	if s.ID() != other.ID() {
+		return false
+	}
+
+	if s.State() != other.State() {
+		return false
+	}
+
+	if s.SourceID() != other.SourceID() {
+		return false
+	}
+
+	if s.CutoverNanos() != other.CutoverNanos() {
+		return false
+	}
+
+	if s.CutoffNanos() != other.CutoffNanos() {
+		return false
+	}
+
+	return true
+}
+
 func (s *shard) Proto() (*placementpb.Shard, error) {
 	ss, err := s.State().Proto()
 	if err != nil {
@@ -196,49 +220,49 @@ type shards struct {
 	shardsMap map[uint32]Shard
 }
 
-func (s shards) All() []Shard {
-	ss := make([]Shard, 0, len(s.shardsMap))
-	for _, shard := range s.shardsMap {
-		ss = append(ss, shard)
+func (ss shards) All() []Shard {
+	shards := make([]Shard, 0, len(ss.shardsMap))
+	for _, shard := range ss.shardsMap {
+		shards = append(shards, shard)
 	}
-	sort.Sort(SortableShardsByIDAsc(ss))
-	return ss
+	sort.Sort(SortableShardsByIDAsc(shards))
+	return shards
 }
 
-func (s shards) AllIDs() []uint32 {
-	ids := make([]uint32, 0, len(s.shardsMap))
-	for _, shard := range s.shardsMap {
+func (ss shards) AllIDs() []uint32 {
+	ids := make([]uint32, 0, len(ss.shardsMap))
+	for _, shard := range ss.shardsMap {
 		ids = append(ids, shard.ID())
 	}
 	sort.Sort(SortableIDsAsc(ids))
 	return ids
 }
 
-func (s shards) NumShards() int {
-	return len(s.shardsMap)
+func (ss shards) NumShards() int {
+	return len(ss.shardsMap)
 }
 
-func (s shards) Shard(id uint32) (Shard, bool) {
-	shard, ok := s.shardsMap[id]
+func (ss shards) Shard(id uint32) (Shard, bool) {
+	shard, ok := ss.shardsMap[id]
 	return shard, ok
 }
 
-func (s shards) Add(shard Shard) {
-	s.shardsMap[shard.ID()] = shard
+func (ss shards) Add(shard Shard) {
+	ss.shardsMap[shard.ID()] = shard
 }
 
-func (s shards) Remove(shard uint32) {
-	delete(s.shardsMap, shard)
+func (ss shards) Remove(shard uint32) {
+	delete(ss.shardsMap, shard)
 }
 
-func (s shards) Contains(shard uint32) bool {
-	_, ok := s.shardsMap[shard]
+func (ss shards) Contains(shard uint32) bool {
+	_, ok := ss.shardsMap[shard]
 	return ok
 }
 
-func (s shards) NumShardsForState(state State) int {
+func (ss shards) NumShardsForState(state State) int {
 	count := 0
-	for _, s := range s.shardsMap {
+	for _, s := range ss.shardsMap {
 		if s.State() == state {
 			count++
 		}
@@ -246,9 +270,9 @@ func (s shards) NumShardsForState(state State) int {
 	return count
 }
 
-func (s shards) ShardsForState(state State) []Shard {
+func (ss shards) ShardsForState(state State) []Shard {
 	var r []Shard
-	for _, s := range s.shardsMap {
+	for _, s := range ss.shardsMap {
 		if s.State() == state {
 			r = append(r, s)
 		}
@@ -256,20 +280,36 @@ func (s shards) ShardsForState(state State) []Shard {
 	return r
 }
 
-func (s shards) String() string {
+func (ss shards) Equals(other Shards) bool {
+	shards := ss.All()
+	otherShards := other.All()
+	if len(shards) != len(otherShards) {
+		return false
+	}
+
+	for i, shard := range shards {
+		otherShard := otherShards[i]
+		if !shard.Equals(otherShard) {
+			return false
+		}
+	}
+	return true
+}
+
+func (ss shards) String() string {
 	var strs []string
 	for _, state := range validStates() {
-		ids := NewShards(s.ShardsForState(state)).AllIDs()
+		ids := NewShards(ss.ShardsForState(state)).AllIDs()
 		str := fmt.Sprintf("%s=%v", state.String(), ids)
 		strs = append(strs, str)
 	}
 	return fmt.Sprintf("[%s]", strings.Join(strs, ", "))
 }
 
-func (s shards) Proto() ([]*placementpb.Shard, error) {
-	res := make([]*placementpb.Shard, 0, len(s.shardsMap))
+func (ss shards) Proto() ([]*placementpb.Shard, error) {
+	res := make([]*placementpb.Shard, 0, len(ss.shardsMap))
 	// All() returns the shards in ID ascending order.
-	for _, shard := range s.All() {
+	for _, shard := range ss.All() {
 		sp, err := shard.Proto()
 		if err != nil {
 			return nil, err

--- a/shard/shard_test.go
+++ b/shard/shard_test.go
@@ -30,10 +30,22 @@ import (
 )
 
 func TestShard(t *testing.T) {
-	s := NewShard(1).SetState(Initializing).SetSourceID("id")
+	s := NewShard(1).SetState(Initializing).SetSourceID("id").SetCutoffNanos(1000).SetCutoverNanos(100)
 	assert.Equal(t, uint32(1), s.ID())
 	assert.Equal(t, Initializing, s.State())
 	assert.Equal(t, "id", s.SourceID())
+	assert.Equal(t, int64(1000), s.CutoffNanos())
+	assert.Equal(t, int64(100), s.CutoverNanos())
+}
+
+func TestShardEqualts(t *testing.T) {
+	s := NewShard(1).SetState(Initializing).SetSourceID("id").SetCutoffNanos(1000).SetCutoverNanos(100)
+	assert.False(t, s.Equals(NewShard(1).SetState(Initializing).SetSourceID("id").SetCutoffNanos(1000)))
+	assert.False(t, s.Equals(NewShard(1).SetState(Initializing).SetSourceID("id").SetCutoverNanos(100)))
+	assert.False(t, s.Equals(NewShard(1).SetState(Initializing).SetCutoffNanos(1000).SetCutoverNanos(100)))
+	assert.False(t, s.Equals(NewShard(1).SetSourceID("id").SetCutoffNanos(1000).SetCutoverNanos(100)))
+	assert.False(t, s.Equals(NewShard(1).SetSourceID("id").SetCutoffNanos(1000).SetCutoverNanos(100)))
+	assert.False(t, s.Equals(NewShard(2).SetState(Initializing).SetSourceID("id").SetCutoffNanos(1000).SetCutoverNanos(100)))
 }
 
 func TestShards(t *testing.T) {
@@ -75,6 +87,22 @@ func TestShards(t *testing.T) {
 
 	shards.Add(NewShard(3).SetState(Leaving))
 	assert.Equal(t, "[Initializing=[1], Available=[2], Leaving=[3]]", shards.String())
+}
+
+func TestShardsEquals(t *testing.T) {
+	ss1 := NewShards(nil)
+	ss2 := NewShards(nil)
+
+	s1 := NewShard(1).SetState(Initializing).SetSourceID("id")
+	s2 := NewShard(2).SetState(Available)
+	ss1.Add(s1)
+	ss2.Add(s2)
+	assert.False(t, ss1.Equals(ss2))
+	ss2.Add(s1)
+	assert.False(t, ss1.Equals(ss2))
+
+	ss2.Remove(s2.ID())
+	assert.True(t, ss1.Equals(ss2))
 }
 
 func TestSort(t *testing.T) {

--- a/shard/types.go
+++ b/shard/types.go
@@ -82,6 +82,9 @@ type Shard interface {
 	// SetSource sets the source of the shard.
 	SetSourceID(sourceID string) Shard
 
+	// Equals returns whether the shard equals to another shard.
+	Equals(s Shard) bool
+
 	// Proto returns the proto representation for the shard.
 	Proto() (*placementpb.Shard, error)
 }
@@ -114,6 +117,9 @@ type Shards interface {
 
 	// Shard returns the shard for the id.
 	Shard(id uint32) (Shard, bool)
+
+	// Equals returns whether the shards equals to another shards.
+	Equals(s Shards) bool
 
 	// String returns the string representation of the shards.
 	String() string


### PR DESCRIPTION
1, Allow replacing instance with Leaving instance in current placement.
2, When removing multiple instances, make sure their shards were only moved to non-leaving instances in the placement.
3. Add Equals() to the Shard interface.

@xichen2020 @prateek @jeromefroe 