### PR TITLE
[travis] Add go 1.8 and 1.9 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.7
-  - 1.8
+  - 1.7.6
+  - 1.8.3
   - 1.9
 install: make install-ci
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
   - 1.7
+  - 1.8
+  - 1.9
 install: make install-ci
 env:
   global:

--- a/kv/etcd/store.go
+++ b/kv/etcd/store.go
@@ -102,7 +102,11 @@ func NewStore(etcdKV clientv3.KV, etcdWatcher clientv3.Watcher, opts Options) (k
 
 		go func() {
 			for range store.cacheUpdatedCh {
-				store.writeCacheToFile()
+				if err := store.writeCacheToFile(); err != nil {
+					store.logger.
+						WithFields(xlog.NewLogErrField(err)).
+						Error("failed to write cache file")
+				}
 			}
 		}()
 	}

--- a/placement/algo/sharded_helper.go
+++ b/placement/algo/sharded_helper.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/m3db/m3x/log"
+
 	"github.com/m3db/m3cluster/placement"
 	"github.com/m3db/m3cluster/shard"
 )
@@ -79,6 +81,7 @@ type placementHelper struct {
 	rf                 int
 	uniqueShards       []uint32
 	instances          map[string]placement.Instance
+	log                xlog.Logger
 	opts               placement.Options
 }
 
@@ -150,6 +153,7 @@ func newHelper(p placement.Placement, targetRF int, opts placement.Options) Plac
 		rf:           targetRF,
 		instances:    make(map[string]placement.Instance, p.NumInstances()),
 		uniqueShards: p.Shards(),
+		log:          opts.InstrumentOptions().Logger(),
 		opts:         opts,
 	}
 
@@ -515,15 +519,23 @@ func (ph *placementHelper) optimize(fn assignLoadFn) {
 }
 
 func (ph *placementHelper) assignLoadToInstanceSafe(addingInstance placement.Instance) {
-	ph.assignTargetLoad(addingInstance, func(from, to placement.Instance) bool {
+	if err := ph.assignTargetLoad(addingInstance, func(from, to placement.Instance) bool {
 		return ph.moveOneShardInState(from, to, shard.Unknown)
-	})
+	}); err != nil {
+		ph.log.
+			WithFields(xlog.NewLogErrField(err)).
+			Error("failed to assign target load to instance")
+	}
 }
 
 func (ph *placementHelper) assignLoadToInstanceUnsafe(addingInstance placement.Instance) {
-	ph.assignTargetLoad(addingInstance, func(from, to placement.Instance) bool {
+	if err := ph.assignTargetLoad(addingInstance, func(from, to placement.Instance) bool {
 		return ph.moveOneShard(from, to)
-	})
+	}); err != nil {
+		ph.log.
+			WithFields(xlog.NewLogErrField(err)).
+			Error("failed to assign target load to instance")
+	}
 }
 
 func (ph *placementHelper) AddInstance(addingInstance placement.Instance) {

--- a/placement/algo/sharded_helper.go
+++ b/placement/algo/sharded_helper.go
@@ -25,10 +25,9 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/m3db/m3x/log"
-
 	"github.com/m3db/m3cluster/placement"
 	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3x/log"
 )
 
 type includeInstanceType int


### PR DESCRIPTION
This PR adds Go 1.8 and 1.9 to the versions of Go we test against in Travis. 

In addition, it seems the `unparam` linter has been updated and caught some new cases, so this PR also addresses the two instances of an error not being used that it found.