### PR TITLE
[util] Return watch from WatchAndUpdate functions

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3e7458fed86a00cc9afeaf1069a0d55a0ff558d4a8c5c0e561e72caa34cf75f8
-updated: 2017-09-13T14:49:25.149990556-04:00
+hash: cae8831c4d4687030f8d331f1a05ffeb54ee545c5d371af273ab25de4b05bd0f
+updated: 2017-09-14T17:06:27.192853437-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -169,11 +169,6 @@ imports:
   version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
 - name: github.com/StackExchange/wmi
   version: e542ed97d15e640bdc14b5c12162d59e8fc67324
-- name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
-  subpackages:
-  - assert
-  - require
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
@@ -240,7 +235,14 @@ testImports:
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/fortytw2/leaktest
+  version: 7dad53304f9614c1c365755c1176a8e876fee3e8
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/stretchr/testify
+  version: d77da356e56a7428ad25149ca77381849a6a5232
+  subpackages:
+  - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,11 +17,6 @@ import:
   - proto
 - package: github.com/m3db/m3x
   version: 6e9713eca6718643e105f574be392f122bcc062e
-- package: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
-  subpackages:
-  - assert
-  - require
 - package: github.com/prometheus/client_model
   version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
 - package: github.com/prometheus/common
@@ -56,3 +51,11 @@ import:
   version: a4bde12657593d5e90d0533a3e4fd95e635124cb
   repo: https://github.com/golang/time
   vcs: git
+testImport:
+- package: github.com/stretchr/testify
+  version: d77da356e56a7428ad25149ca77381849a6a5232
+  subpackages:
+  - assert
+  - require
+- package: github.com/fortytw2/leaktest
+  version: ^1.1.0

--- a/kv/util/util.go
+++ b/kv/util/util.go
@@ -37,7 +37,7 @@ var (
 
 // WatchAndUpdateBool sets up a watch with validation for a bool property. Any
 // malformed or invalid updates are not applied. The default value is applied
-// when the key does not exist in KV.
+// when the key does not exist in KV. The watch on the value is returned.
 func WatchAndUpdateBool(
 	store kv.Store,
 	key string,
@@ -45,7 +45,7 @@ func WatchAndUpdateBool(
 	lock sync.Locker,
 	defaultValue bool,
 	opts Options,
-) error {
+) (kv.ValueWatch, error) {
 	if opts == nil {
 		opts = NewOptions()
 	}
@@ -58,7 +58,7 @@ func WatchAndUpdateBool(
 
 // WatchAndUpdateFloat64 sets up a watch with validation for a float64 property.
 // Any malformed or invalid updates are not applied. The default value is applied
-// when the key does not exist in KV.
+// when the key does not exist in KV. The watch on the value is returned.
 func WatchAndUpdateFloat64(
 	store kv.Store,
 	key string,
@@ -66,7 +66,7 @@ func WatchAndUpdateFloat64(
 	lock sync.Locker,
 	defaultValue float64,
 	opts Options,
-) error {
+) (kv.ValueWatch, error) {
 	if opts == nil {
 		opts = NewOptions()
 	}
@@ -79,7 +79,7 @@ func WatchAndUpdateFloat64(
 
 // WatchAndUpdateInt64 sets up a watch with validation for an int64 property. Any
 // malformed or invalid updates are not applied. The default value is applied when
-// the key does not exist in KV.
+// the key does not exist in KV. The watch on the value is returned.
 func WatchAndUpdateInt64(
 	store kv.Store,
 	key string,
@@ -87,7 +87,7 @@ func WatchAndUpdateInt64(
 	lock sync.Locker,
 	defaultValue int64,
 	opts Options,
-) error {
+) (kv.ValueWatch, error) {
 	if opts == nil {
 		opts = NewOptions()
 	}
@@ -100,7 +100,7 @@ func WatchAndUpdateInt64(
 
 // WatchAndUpdateString sets up a watch with validation for a string property. Any
 // malformed or invalid updates are not applied. The default value is applied when
-// the key does not exist in KV.
+// the key does not exist in KV. The watch on the value is returned.
 func WatchAndUpdateString(
 	store kv.Store,
 	key string,
@@ -108,7 +108,7 @@ func WatchAndUpdateString(
 	lock sync.Locker,
 	defaultValue string,
 	opts Options,
-) error {
+) (kv.ValueWatch, error) {
 	if opts == nil {
 		opts = NewOptions()
 	}
@@ -121,7 +121,7 @@ func WatchAndUpdateString(
 
 // WatchAndUpdateStringArray sets up a watch with validation for a string array
 // property. Any malformed, or invalid updates are not applied. The default value
-// is applied when the key does not exist in KV.
+// is applied when the key does not exist in KV. The watch on the value is returned.
 func WatchAndUpdateStringArray(
 	store kv.Store,
 	key string,
@@ -129,7 +129,7 @@ func WatchAndUpdateStringArray(
 	lock sync.Locker,
 	defaultValue []string,
 	opts Options,
-) error {
+) (kv.ValueWatch, error) {
 	if opts == nil {
 		opts = NewOptions()
 	}
@@ -142,7 +142,7 @@ func WatchAndUpdateStringArray(
 
 // WatchAndUpdateTime sets up a watch with validation for a time property. Any
 // malformed, or invalid updates are not applied. The default value is applied
-// when the key does not exist in KV.
+// when the key does not exist in KV. The watch on the value is returned.
 func WatchAndUpdateTime(
 	store kv.Store,
 	key string,
@@ -150,7 +150,7 @@ func WatchAndUpdateTime(
 	lock sync.Locker,
 	defaultValue time.Time,
 	opts Options,
-) error {
+) (kv.ValueWatch, error) {
 	if opts == nil {
 		opts = NewOptions()
 	}
@@ -349,9 +349,9 @@ func watchAndUpdate(
 	validate ValidateFn,
 	defaultValue interface{},
 	logger log.Logger,
-) error {
+) (kv.ValueWatch, error) {
 	if store == nil {
-		return errNilStore
+		return nil, errNilStore
 	}
 
 	var (
@@ -361,7 +361,7 @@ func watchAndUpdate(
 
 	watch, err = store.Watch(key)
 	if err != nil {
-		return fmt.Errorf("could not establish initial watch: %v", err)
+		return nil, fmt.Errorf("could not establish initial watch: %v", err)
 	}
 
 	go func() {
@@ -374,7 +374,7 @@ func watchAndUpdate(
 			Error("watch unexpectedly closed")
 	}()
 
-	return err
+	return watch, nil
 }
 
 func updateWithKV(

--- a/kv/util/util_test.go
+++ b/kv/util/util_test.go
@@ -58,7 +58,9 @@ func TestWatchAndUpdateBool(t *testing.T) {
 		defaultValue = false
 	)
 
-	err := WatchAndUpdateBool(store, "foo", &testConfig.v, &testConfig.RWMutex, defaultValue, nil)
+	watch, err := WatchAndUpdateBool(
+		store, "foo", &testConfig.v, &testConfig.RWMutex, defaultValue, nil,
+	)
 	require.NoError(t, err)
 
 	// Valid update.
@@ -100,6 +102,14 @@ func TestWatchAndUpdateBool(t *testing.T) {
 			break
 		}
 	}
+
+	// Updates should not be applied after the watch is closed.
+	watch.Close()
+	time.Sleep(100 * time.Millisecond)
+	_, err = store.Set("foo", &commonpb.BoolProto{Value: false})
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	require.True(t, valueFn())
 }
 
 func TestWatchAndUpdateFloat64(t *testing.T) {
@@ -120,7 +130,9 @@ func TestWatchAndUpdateFloat64(t *testing.T) {
 		defaultValue = 1.35
 	)
 
-	err := WatchAndUpdateFloat64(store, "foo", &testConfig.v, &testConfig.RWMutex, defaultValue, nil)
+	watch, err := WatchAndUpdateFloat64(
+		store, "foo", &testConfig.v, &testConfig.RWMutex, defaultValue, nil,
+	)
 	require.NoError(t, err)
 
 	_, err = store.Set("foo", &commonpb.Float64Proto{Value: 3.7})
@@ -161,6 +173,14 @@ func TestWatchAndUpdateFloat64(t *testing.T) {
 			break
 		}
 	}
+
+	// Updates should not be applied after the watch is closed.
+	watch.Close()
+	time.Sleep(100 * time.Millisecond)
+	_, err = store.Set("foo", &commonpb.Float64Proto{Value: 7.2})
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 6.2, valueFn())
 }
 
 func TestWatchAndUpdateInt64(t *testing.T) {
@@ -181,7 +201,9 @@ func TestWatchAndUpdateInt64(t *testing.T) {
 		defaultValue int64 = 3
 	)
 
-	err := WatchAndUpdateInt64(store, "foo", &testConfig.v, &testConfig.RWMutex, defaultValue, nil)
+	watch, err := WatchAndUpdateInt64(
+		store, "foo", &testConfig.v, &testConfig.RWMutex, defaultValue, nil,
+	)
 	require.NoError(t, err)
 
 	_, err = store.Set("foo", &commonpb.Int64Proto{Value: 1})
@@ -222,6 +244,14 @@ func TestWatchAndUpdateInt64(t *testing.T) {
 			break
 		}
 	}
+
+	// Updates should not be applied after the watch is closed.
+	watch.Close()
+	time.Sleep(100 * time.Millisecond)
+	_, err = store.Set("foo", &commonpb.Int64Proto{Value: 13})
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, int64(21), valueFn())
 }
 
 func TestWatchAndUpdateString(t *testing.T) {
@@ -242,7 +272,9 @@ func TestWatchAndUpdateString(t *testing.T) {
 		defaultValue = "abc"
 	)
 
-	err := WatchAndUpdateString(store, "foo", &testConfig.v, &testConfig.RWMutex, defaultValue, nil)
+	watch, err := WatchAndUpdateString(
+		store, "foo", &testConfig.v, &testConfig.RWMutex, defaultValue, nil,
+	)
 	require.NoError(t, err)
 
 	_, err = store.Set("foo", &commonpb.StringProto{Value: "fizz"})
@@ -283,6 +315,14 @@ func TestWatchAndUpdateString(t *testing.T) {
 			break
 		}
 	}
+
+	// Updates should not be applied after the watch is closed.
+	watch.Close()
+	time.Sleep(100 * time.Millisecond)
+	_, err = store.Set("foo", &commonpb.StringProto{Value: "abc"})
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, "lol", valueFn())
 }
 
 func TestWatchAndUpdateStringArray(t *testing.T) {
@@ -303,7 +343,7 @@ func TestWatchAndUpdateStringArray(t *testing.T) {
 		defaultValue = []string{"abc", "def"}
 	)
 
-	err := WatchAndUpdateStringArray(
+	watch, err := WatchAndUpdateStringArray(
 		store, "foo", &testConfig.v, &testConfig.RWMutex, defaultValue, nil,
 	)
 	require.NoError(t, err)
@@ -346,6 +386,14 @@ func TestWatchAndUpdateStringArray(t *testing.T) {
 			break
 		}
 	}
+
+	// Updates should not be applied after the watch is closed.
+	watch.Close()
+	time.Sleep(100 * time.Millisecond)
+	_, err = store.Set("foo", &commonpb.StringArrayProto{Values: []string{"abc", "def"}})
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, []string{"jim", "jam"}, valueFn())
 }
 
 func TestWatchAndUpdateTime(t *testing.T) {
@@ -366,7 +414,7 @@ func TestWatchAndUpdateTime(t *testing.T) {
 		defaultValue = time.Now()
 	)
 
-	err := WatchAndUpdateTime(store, "foo", &testConfig.v, &testConfig.RWMutex, defaultValue, nil)
+	watch, err := WatchAndUpdateTime(store, "foo", &testConfig.v, &testConfig.RWMutex, defaultValue, nil)
 	require.NoError(t, err)
 
 	newTime := defaultValue.Add(time.Minute)
@@ -410,6 +458,14 @@ func TestWatchAndUpdateTime(t *testing.T) {
 			break
 		}
 	}
+
+	// Updates should not be applied after the watch is closed.
+	watch.Close()
+	time.Sleep(100 * time.Millisecond)
+	_, err = store.Set("foo", &commonpb.Int64Proto{Value: defaultValue.Unix()})
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, newTime.Unix(), valueFn().Unix())
 }
 
 func TestWatchAndUpdateWithValidationBool(t *testing.T) {
@@ -430,7 +486,7 @@ func TestWatchAndUpdateWithValidationBool(t *testing.T) {
 		opts  = NewOptions().SetValidateFn(testValidateBoolFn)
 	)
 
-	err := WatchAndUpdateBool(store, "foo", &testConfig.v, &testConfig.RWMutex, false, opts)
+	_, err := WatchAndUpdateBool(store, "foo", &testConfig.v, &testConfig.RWMutex, false, opts)
 	require.NoError(t, err)
 
 	_, err = store.Set("foo", &commonpb.BoolProto{Value: true})
@@ -469,7 +525,7 @@ func TestWatchAndUpdateWithValidationFloat64(t *testing.T) {
 		opts  = NewOptions().SetValidateFn(testValidateFloat64Fn)
 	)
 
-	err := WatchAndUpdateFloat64(store, "foo", &testConfig.v, &testConfig.RWMutex, 1.2, opts)
+	_, err := WatchAndUpdateFloat64(store, "foo", &testConfig.v, &testConfig.RWMutex, 1.2, opts)
 	require.NoError(t, err)
 
 	_, err = store.Set("foo", &commonpb.Float64Proto{Value: 17})
@@ -513,7 +569,7 @@ func TestWatchAndUpdateWithValidationInt64(t *testing.T) {
 		opts  = NewOptions().SetValidateFn(testValidateInt64Fn)
 	)
 
-	err := WatchAndUpdateInt64(store, "foo", &testConfig.v, &testConfig.RWMutex, 16, opts)
+	_, err := WatchAndUpdateInt64(store, "foo", &testConfig.v, &testConfig.RWMutex, 16, opts)
 	require.NoError(t, err)
 
 	_, err = store.Set("foo", &commonpb.Int64Proto{Value: 17})
@@ -557,7 +613,7 @@ func TestWatchAndUpdateWithValidationString(t *testing.T) {
 		opts  = NewOptions().SetValidateFn(testValidateStringFn)
 	)
 
-	err := WatchAndUpdateString(store, "foo", &testConfig.v, &testConfig.RWMutex, "bcd", opts)
+	_, err := WatchAndUpdateString(store, "foo", &testConfig.v, &testConfig.RWMutex, "bcd", opts)
 	require.NoError(t, err)
 
 	_, err = store.Set("foo", &commonpb.StringProto{Value: "bar"})
@@ -601,7 +657,7 @@ func TestWatchAndUpdateWithValidationStringArray(t *testing.T) {
 		opts  = NewOptions().SetValidateFn(testValidateStringArrayFn)
 	)
 
-	err := WatchAndUpdateStringArray(
+	_, err := WatchAndUpdateStringArray(
 		store, "foo", &testConfig.v, &testConfig.RWMutex, []string{"a", "b"}, opts,
 	)
 	require.NoError(t, err)
@@ -647,7 +703,7 @@ func TestWatchAndUpdateWithValidationTime(t *testing.T) {
 		opts  = NewOptions().SetValidateFn(testValidateTimeFn)
 	)
 
-	err := WatchAndUpdateTime(store, "foo", &testConfig.v, &testConfig.RWMutex, testNow, opts)
+	_, err := WatchAndUpdateTime(store, "foo", &testConfig.v, &testConfig.RWMutex, testNow, opts)
 	require.NoError(t, err)
 
 	newTime := testNow.Add(30 * time.Second)

--- a/kv/util/util_test.go
+++ b/kv/util/util_test.go
@@ -28,11 +28,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/m3db/m3cluster/generated/proto/commonpb"
 	"github.com/m3db/m3cluster/kv"
 	"github.com/m3db/m3cluster/kv/mem"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/kv/util/util_test.go
+++ b/kv/util/util_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/m3db/m3cluster/generated/proto/commonpb"
 	"github.com/m3db/m3cluster/kv"
 	"github.com/m3db/m3cluster/kv/mem"
@@ -103,13 +104,16 @@ func TestWatchAndUpdateBool(t *testing.T) {
 		}
 	}
 
-	// Updates should not be applied after the watch is closed.
+	// Updates should not be applied after the watch is closed and there should not
+	// be any goroutines still running.
 	watch.Close()
 	time.Sleep(100 * time.Millisecond)
 	_, err = store.Set("foo", &commonpb.BoolProto{Value: false})
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)
 	require.True(t, valueFn())
+
+	leaktest.Check(t)()
 }
 
 func TestWatchAndUpdateFloat64(t *testing.T) {
@@ -174,13 +178,16 @@ func TestWatchAndUpdateFloat64(t *testing.T) {
 		}
 	}
 
-	// Updates should not be applied after the watch is closed.
+	// Updates should not be applied after the watch is closed and there should not
+	// be any goroutines still running.
 	watch.Close()
 	time.Sleep(100 * time.Millisecond)
 	_, err = store.Set("foo", &commonpb.Float64Proto{Value: 7.2})
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)
 	require.Equal(t, 6.2, valueFn())
+
+	leaktest.Check(t)
 }
 
 func TestWatchAndUpdateInt64(t *testing.T) {
@@ -245,13 +252,16 @@ func TestWatchAndUpdateInt64(t *testing.T) {
 		}
 	}
 
-	// Updates should not be applied after the watch is closed.
+	// Updates should not be applied after the watch is closed and there should not
+	// be any goroutines still running.
 	watch.Close()
 	time.Sleep(100 * time.Millisecond)
 	_, err = store.Set("foo", &commonpb.Int64Proto{Value: 13})
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)
 	require.Equal(t, int64(21), valueFn())
+
+	leaktest.Check(t)
 }
 
 func TestWatchAndUpdateString(t *testing.T) {
@@ -316,13 +326,16 @@ func TestWatchAndUpdateString(t *testing.T) {
 		}
 	}
 
-	// Updates should not be applied after the watch is closed.
+	// Updates should not be applied after the watch is closed and there should not
+	// be any goroutines still running.
 	watch.Close()
 	time.Sleep(100 * time.Millisecond)
 	_, err = store.Set("foo", &commonpb.StringProto{Value: "abc"})
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)
 	require.Equal(t, "lol", valueFn())
+
+	leaktest.Check(t)
 }
 
 func TestWatchAndUpdateStringArray(t *testing.T) {
@@ -387,13 +400,16 @@ func TestWatchAndUpdateStringArray(t *testing.T) {
 		}
 	}
 
-	// Updates should not be applied after the watch is closed.
+	// Updates should not be applied after the watch is closed and there should not
+	// be any goroutines still running.
 	watch.Close()
 	time.Sleep(100 * time.Millisecond)
 	_, err = store.Set("foo", &commonpb.StringArrayProto{Values: []string{"abc", "def"}})
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)
 	require.Equal(t, []string{"jim", "jam"}, valueFn())
+
+	leaktest.Check(t)
 }
 
 func TestWatchAndUpdateTime(t *testing.T) {
@@ -459,13 +475,16 @@ func TestWatchAndUpdateTime(t *testing.T) {
 		}
 	}
 
-	// Updates should not be applied after the watch is closed.
+	// Updates should not be applied after the watch is closed and there should not
+	// be any goroutines still running.
 	watch.Close()
 	time.Sleep(100 * time.Millisecond)
 	_, err = store.Set("foo", &commonpb.Int64Proto{Value: defaultValue.Unix()})
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)
 	require.Equal(t, newTime.Unix(), valueFn().Unix())
+
+	leaktest.Check(t)
 }
 
 func TestWatchAndUpdateWithValidationBool(t *testing.T) {


### PR DESCRIPTION
This PR returns the ValueWatches from the `WatchAndUpdate` functions so the caller can close them if they need to. Callers would then be able to ensure that the goroutines which watch for these updates will be closed.

cc @prateek @cw9 