### PR TITLE
Fix the bug where instance could reclaim all of its leaving shards

### DIFF
--- a/placement/algo/sharded.go
+++ b/placement/algo/sharded.go
@@ -113,7 +113,7 @@ func (a rackAwarePlacementAlgorithm) RemoveInstances(
 			return nil, err
 		}
 
-		if p, _, err = addInstanceToPlacement(ph.GeneratePlacement(), leavingInstance, nonEmptyOnly); err != nil {
+		if p, _, err = addInstanceToPlacement(ph.GeneratePlacement(), leavingInstance, withShards); err != nil {
 			return nil, err
 		}
 	}
@@ -130,7 +130,7 @@ func (a rackAwarePlacementAlgorithm) AddInstances(
 
 	p = p.Clone()
 	for _, instance := range instances {
-		ph, addingInstance, err := newAddEmptyInstanceHelper(p, instance, a.opts)
+		ph, addingInstance, err := newAddInstanceHelper(p, instance, a.opts, withLeavingShardsOnly)
 		if err != nil {
 			return nil, err
 		}
@@ -169,7 +169,7 @@ func (a rackAwarePlacementAlgorithm) ReplaceInstances(
 		}
 		load := loadOnInstance(leavingInstance)
 		if load == 0 {
-			result, _, err := addInstanceToPlacement(ph.GeneratePlacement(), leavingInstance, nonEmptyOnly)
+			result, _, err := addInstanceToPlacement(ph.GeneratePlacement(), leavingInstance, withShards)
 			return result, err
 		}
 		if !a.opts.AllowPartialReplace() {
@@ -192,7 +192,7 @@ func (a rackAwarePlacementAlgorithm) ReplaceInstances(
 	}
 
 	for _, leavingInstance := range leavingInstances {
-		p, _, err = addInstanceToPlacement(ph.GeneratePlacement(), leavingInstance, nonEmptyOnly)
+		p, _, err = addInstanceToPlacement(ph.GeneratePlacement(), leavingInstance, withShards)
 		if err != nil {
 			return nil, err
 		}

--- a/placement/algo/sharded.go
+++ b/placement/algo/sharded.go
@@ -29,7 +29,6 @@ import (
 
 var (
 	errNotEnoughRacks              = errors.New("not enough racks to take shards, please make sure RF is less than number of racks")
-	errAddingInstanceAlreadyExist  = errors.New("the adding instance is already in the placement")
 	errIncompatibleWithShardedAlgo = errors.New("could not apply sharded algo on the placement")
 )
 
@@ -131,7 +130,7 @@ func (a rackAwarePlacementAlgorithm) AddInstances(
 
 	p = p.Clone()
 	for _, instance := range instances {
-		ph, addingInstance, err := newAddInstanceHelper(p, instance, a.opts)
+		ph, addingInstance, err := newAddEmptyInstanceHelper(p, instance, a.opts)
 		if err != nil {
 			return nil, err
 		}

--- a/placement/algo/sharded_helper.go
+++ b/placement/algo/sharded_helper.go
@@ -134,7 +134,7 @@ func newAddInstanceHelper(
 	switch t {
 	case withLeavingShardsOnly:
 		if !instanceInPlacement.IsLeaving() {
-			return nil, nil, errAddingInstanceAlreadyExist
+			return nil, nil, errInstanceContainsNonLeavingShards
 		}
 	case withAvailableOrLeavingShardsOnly:
 		shards := instanceInPlacement.Shards()


### PR DESCRIPTION
In very rare case, the leaving shards could not be taken back due to rack conflicts.
For example, in a RF=2 case, instance a and b on rack1, instance c on rack2, instance d on rack3,
a and c owns shard 1, 

Remove a and c:
1, a give shard 1 to d
2, c give shard 1 to b

Add a and c back:
Now if a tries to get shard 1 back from d there will be a rack conflict because b(on the same rack with a) owns shard 1 as well.
This rack conflict can be resolved by having c take the shard back from b first, then a can take the shard back from d without rack conflict.

This diff introduces a loop that retries the shard reclaiming process as long as some instance are still making progress.

@xichen2020 @prateek @jeromefroe 