### PR TITLE
Fix flaky unit test

### DIFF
--- a/kv/util/util_test.go
+++ b/kv/util/util_test.go
@@ -99,7 +99,7 @@ func TestWatchAndUpdateBool(t *testing.T) {
 	_, err = store.Set("foo", &commonpb.BoolProto{Value: true})
 	require.NoError(t, err)
 	for {
-		if !valueFn() {
+		if valueFn() {
 			break
 		}
 	}


### PR DESCRIPTION
The unit test before only passes if the valueFn() was evaluated before the watch got the update, otherwise it'll block forever

@jeromefroe @xichen2020 @prateek 