### PR TITLE
basic plumbing to allow setting client tls for kv clusters

### DIFF
--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -245,7 +245,7 @@ func (c *csclient) etcdClientGen(zone string) (*clientv3.Client, error) {
 
 func newClient(endpoints []string, certfile string, keyfile string, ca string) (*clientv3.Client, error) {
 	tlscfg := &tls.Config{}
-	if certfile != "" && keyfile != "" {
+	if certfile != "" {
 		cert, err := tls.LoadX509KeyPair(certfile, keyfile)
 		if err != nil {
 			return nil, err
@@ -261,8 +261,7 @@ func newClient(endpoints []string, certfile string, keyfile string, ca string) (
 				return nil, err
 			}
 			caPool := x509.NewCertPool()
-			ok := caPool.AppendCertsFromPEM(caCert)
-			if !ok {
+			if ok := caPool.AppendCertsFromPEM(caCert); !ok {
 				return nil, fmt.Errorf("can't read PEM-formatted certificates from file %s as root CA pool", ca)
 			}
 			tlscfg.RootCAs = caPool

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -252,7 +252,7 @@ func newClient(endpoints []string, certfile string, keyfile string, ca string) (
 		}
 		tlscfg = &tls.Config{
 			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: false,
 			Certificates:       []tls.Certificate{cert},
 		}
 		if ca != "" {

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,6 +39,7 @@ import (
 	etcdheartbeat "github.com/m3db/m3cluster/services/heartbeat/etcd"
 	"github.com/m3db/m3cluster/services/leader"
 	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/log"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/uber-go/tally"

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -21,8 +21,12 @@
 package etcd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +40,6 @@ import (
 	etcdheartbeat "github.com/m3db/m3cluster/services/heartbeat/etcd"
 	"github.com/m3db/m3cluster/services/leader"
 	"github.com/m3db/m3x/instrument"
-	"github.com/m3db/m3x/log"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/uber-go/tally"
@@ -53,7 +56,7 @@ const (
 
 var errInvalidNamespace = errors.New("invalid namespace")
 
-type newClientFn func(endpoints []string) (*clientv3.Client, error)
+type newClientFn func(endpoints []string, cert string, key string, ca string) (*clientv3.Client, error)
 
 type cacheFileForZoneFn func(zone string) etcdkv.CacheFileFn
 
@@ -231,7 +234,7 @@ func (c *csclient) etcdClientGen(zone string) (*clientv3.Client, error) {
 		return nil, fmt.Errorf("no etcd cluster found for zone %s", zone)
 	}
 
-	cli, err := c.newFn(cluster.Endpoints())
+	cli, err := c.newFn(cluster.Endpoints(), cluster.Cert(), cluster.Key(), cluster.CA())
 	if err != nil {
 		return nil, err
 	}
@@ -240,8 +243,32 @@ func (c *csclient) etcdClientGen(zone string) (*clientv3.Client, error) {
 	return cli, nil
 }
 
-func newClient(endpoints []string) (*clientv3.Client, error) {
-	return clientv3.New(clientv3.Config{Endpoints: endpoints})
+func newClient(endpoints []string, certfile string, keyfile string, ca string) (*clientv3.Client, error) {
+	tlscfg := &tls.Config{}
+	if certfile != "" && keyfile != "" {
+		cert, err := tls.LoadX509KeyPair(certfile, keyfile)
+		if err != nil {
+			return nil, err
+		}
+		tlscfg = &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: true,
+			Certificates:       []tls.Certificate{cert},
+		}
+		if ca != "" {
+			caCert, err := ioutil.ReadFile(ca)
+			if err != nil {
+				return nil, err
+			}
+			caPool := x509.NewCertPool()
+			ok := caPool.AppendCertsFromPEM(caCert)
+			if !ok {
+				return nil, fmt.Errorf("can't read PEM-formatted certificates from file %s as root CA pool", ca)
+			}
+			tlscfg.RootCAs = caPool
+		}
+	}
+	return clientv3.New(clientv3.Config{Endpoints: endpoints, TLS: tlscfg})
 }
 
 func (c *csclient) cacheFileFn(extraFields ...string) cacheFileForZoneFn {

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -49,6 +49,18 @@ func TestETCDClientGen(t *testing.T) {
 	require.Equal(t, 2, len(c.clis))
 	require.NotEqual(t, c1, c2)
 
+	_, err = c.etcdClientGen("zone3")
+	require.Error(t, err)
+	require.Equal(t, 2, len(c.clis))
+
+	// TODO(pwoodman): bit of a cop-out- this'll error no matter what as it's looking for
+	// a file that won't be in the test environment. So, expect error.
+	_, err = c.etcdClientGen("zone4")
+	require.Error(t, err)
+
+	_, err = c.etcdClientGen("zone5")
+	require.Error(t, err)
+
 	c1Again, err := c.etcdClientGen("zone1")
 	require.NoError(t, err)
 	require.Equal(t, 2, len(c.clis))
@@ -266,7 +278,12 @@ func testOptions() Options {
 	return NewOptions().SetClusters([]Cluster{
 		NewCluster().SetZone("zone1").SetEndpoints([]string{"i1"}),
 		NewCluster().SetZone("zone2").SetEndpoints([]string{"i2"}),
-		NewCluster().SetZone("zone3").SetEndpoints([]string{"i3"}),
+		NewCluster().SetZone("zone3").SetEndpoints([]string{"i3"}).
+			SetCert("foo.crt.pem"),
+		NewCluster().SetZone("zone4").SetEndpoints([]string{"i4"}).
+			SetCert("foo.crt.pem").SetKey("foo.key.pem"),
+		NewCluster().SetZone("zone5").SetEndpoints([]string{"i5"}).
+			SetCert("foo.crt.pem").SetKey("foo.key.pem").SetCA("foo_ca.pem"),
 	}).SetService("test_app").SetZone("zone1")
 }
 

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -274,7 +274,7 @@ func testNewETCDFn(t *testing.T) (newClientFn, func()) {
 	ecluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
 	ec := ecluster.RandClient()
 
-	newFn := func(endpoints []string) (*clientv3.Client, error) {
+	newFn := func(endpoints []string, cert string, key string) (*clientv3.Client, error) {
 		return ec, nil
 	}
 

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -274,7 +274,7 @@ func testNewETCDFn(t *testing.T) (newClientFn, func()) {
 	ecluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
 	ec := ecluster.RandClient()
 
-	newFn := func(endpoints []string, cert string, key string) (*clientv3.Client, error) {
+	newFn := func(endpoints []string, cert string, key string, ca string) (*clientv3.Client, error) {
 		return ec, nil
 	}
 

--- a/client/etcd/config.go
+++ b/client/etcd/config.go
@@ -30,6 +30,9 @@ import (
 type ClusterConfig struct {
 	Zone      string   `yaml:"zone"`
 	Endpoints []string `yaml:"endpoints"`
+	Cert      string   `yaml:"cert",omitempty`
+	Key       string   `yaml:"key",omitempty`
+	CA        string   `yaml:"ca",omitempty`
 }
 
 // Configuration is for config service client
@@ -63,7 +66,10 @@ func (cfg Configuration) etcdClusters() []Cluster {
 	for i, c := range cfg.ETCDClusters {
 		res[i] = NewCluster().
 			SetZone(c.Zone).
-			SetEndpoints(c.Endpoints)
+			SetEndpoints(c.Endpoints).
+			SetCert(c.Cert).
+			SetKey(c.Key).
+			SetCA(c.CA)
 	}
 
 	return res

--- a/client/etcd/config_test.go
+++ b/client/etcd/config_test.go
@@ -79,7 +79,7 @@ func TestConfig(t *testing.T) {
 		},
 		ClusterConfig{
 			Zone:      "z3",
-			Endpoints: []string{"etcd3:2379", "etcd4:2379"},
+			Endpoints: []string{"etcd5:2379", "etcd6:2379"},
 			Cert:      "foo.crt.pem",
 			Key:       "foo.key.pem",
 			CA:        "foo_ca.pem",

--- a/client/etcd/config_test.go
+++ b/client/etcd/config_test.go
@@ -53,7 +53,7 @@ const testConfig = `
               - etcd6:2379
           cert: foo.crt.pem
           key: foo.key.pem
-		  ca: foo_ca.pem
+          ca: foo_ca.pem
     m3sd:
         initTimeout: 10s
 `

--- a/client/etcd/config_test.go
+++ b/client/etcd/config_test.go
@@ -45,6 +45,15 @@ const testConfig = `
           endpoints:
               - etcd3:2379
               - etcd4:2379
+          cert: foo.crt.pem
+          key: foo.key.pem
+        - zone: z3
+          endpoints:
+              - etcd5:2379
+              - etcd6:2379
+          cert: foo.crt.pem
+          key: foo.key.pem
+		  ca: foo_ca.pem
     m3sd:
         initTimeout: 10s
 `
@@ -61,8 +70,20 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, "service1", cfg.Service)
 	require.Equal(t, "/tmp/cache.json", cfg.CacheDir)
 	require.Equal(t, []ClusterConfig{
-		ClusterConfig{"z1", []string{"etcd1:2379", "etcd2:2379"}},
-		ClusterConfig{"z2", []string{"etcd3:2379", "etcd4:2379"}},
+		ClusterConfig{Zone: "z1", Endpoints: []string{"etcd1:2379", "etcd2:2379"}},
+		ClusterConfig{
+			Zone:      "z2",
+			Endpoints: []string{"etcd3:2379", "etcd4:2379"},
+			Cert:      "foo.crt.pem",
+			Key:       "foo.key.pem",
+		},
+		ClusterConfig{
+			Zone:      "z3",
+			Endpoints: []string{"etcd3:2379", "etcd4:2379"},
+			Cert:      "foo.crt.pem",
+			Key:       "foo.key.pem",
+			CA:        "foo_ca.pem",
+		},
 	}, cfg.ETCDClusters)
 	require.Equal(t, 10*time.Second, cfg.SDConfig.InitTimeout)
 }

--- a/client/etcd/options.go
+++ b/client/etcd/options.go
@@ -61,6 +61,13 @@ type Cluster interface {
 
 	Endpoints() []string
 	SetEndpoints(endpoints []string) Cluster
+
+	Cert() string
+	SetCert(string) Cluster
+	Key() string
+	SetKey(string) Cluster
+	CA() string
+	SetCA(string) Cluster
 }
 
 // NewOptions creates a set of Options
@@ -172,6 +179,9 @@ func (o options) SetInstrumentOptions(iopts instrument.Options) Options {
 type cluster struct {
 	zone      string
 	endpoints []string
+	cert      string
+	key       string
+	ca        string
 }
 
 // NewCluster creates a Cluster
@@ -194,5 +204,30 @@ func (c cluster) Endpoints() []string {
 
 func (c cluster) SetEndpoints(endpoints []string) Cluster {
 	c.endpoints = endpoints
+	return c
+}
+
+func (c cluster) Cert() string {
+	return c.cert
+}
+
+func (c cluster) SetCert(cert string) Cluster {
+	c.cert = cert
+	return c
+}
+
+func (c cluster) Key() string {
+	return c.key
+}
+func (c cluster) SetKey(key string) Cluster {
+	c.key = key
+	return c
+}
+
+func (c cluster) CA() string {
+	return c.ca
+}
+func (c cluster) SetCA(ca string) Cluster {
+	c.ca = ca
 	return c
 }

--- a/client/etcd/options_test.go
+++ b/client/etcd/options_test.go
@@ -34,14 +34,32 @@ func TestCluster(t *testing.T) {
 	c := NewCluster()
 	assert.Equal(t, "", c.Zone())
 	assert.Equal(t, 0, len(c.Endpoints()))
+	assert.Equal(t, "", c.Cert())
+	assert.Equal(t, "", c.Key())
 
 	c = c.SetZone("z")
 	assert.Equal(t, "z", c.Zone())
 	assert.Equal(t, 0, len(c.Endpoints()))
+	assert.Equal(t, "", c.Cert())
+	assert.Equal(t, "", c.Key())
 
 	c = c.SetEndpoints([]string{"e1"})
 	assert.Equal(t, "z", c.Zone())
 	assert.Equal(t, []string{"e1"}, c.Endpoints())
+	assert.Equal(t, "", c.Cert())
+	assert.Equal(t, "", c.Key())
+
+	c = c.SetCert("self.crt.pem")
+	assert.Equal(t, "z", c.Zone())
+	assert.Equal(t, []string{"e1"}, c.Endpoints())
+	assert.Equal(t, "self.crt.pem", c.Cert())
+	assert.Equal(t, "", c.Key())
+
+	c = c.SetKey("self.key.pem")
+	assert.Equal(t, "z", c.Zone())
+	assert.Equal(t, []string{"e1"}, c.Endpoints())
+	assert.Equal(t, "self.crt.pem", c.Cert())
+	assert.Equal(t, "self.key.pem", c.Key())
 }
 
 func TestOptions(t *testing.T) {


### PR DESCRIPTION
with this change we can distribute certs with langley and use them for auth, rather than exposing a bare etcd cluster to the company. can use a read-only cert in the proxy to avoid anyone accidentally trying to write stuff to KV after looking at the collector.