### PR TITLE
Use nil tls config by default

### DIFF
--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -244,7 +244,7 @@ func (c *csclient) etcdClientGen(zone string) (*clientv3.Client, error) {
 }
 
 func newClient(endpoints []string, certfile string, keyfile string, ca string) (*clientv3.Client, error) {
-	tlscfg := &tls.Config{}
+	var tlscfg *tls.Config
 	if certfile != "" {
 		cert, err := tls.LoadX509KeyPair(certfile, keyfile)
 		if err != nil {


### PR DESCRIPTION
Currently we use an empty tls config by default, which causes the auth to fail when no certificate provided in config, should use nil for the no-auth case

@xichen2020 @prateek @jeromefroe 