### PR TITLE
Refactor TLS configuration

### DIFF
--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -21,11 +21,8 @@
 package etcd
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,7 +53,7 @@ const (
 
 var errInvalidNamespace = errors.New("invalid namespace")
 
-type newClientFn func(endpoints []string, cert string, key string, ca string) (*clientv3.Client, error)
+type newClientFn func(cluster Cluster) (*clientv3.Client, error)
 
 type cacheFileForZoneFn func(zone string) etcdkv.CacheFileFn
 
@@ -234,7 +231,7 @@ func (c *csclient) etcdClientGen(zone string) (*clientv3.Client, error) {
 		return nil, fmt.Errorf("no etcd cluster found for zone %s", zone)
 	}
 
-	cli, err := c.newFn(cluster.Endpoints(), cluster.Cert(), cluster.Key(), cluster.CA())
+	cli, err := c.newFn(cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -243,31 +240,13 @@ func (c *csclient) etcdClientGen(zone string) (*clientv3.Client, error) {
 	return cli, nil
 }
 
-func newClient(endpoints []string, certfile string, keyfile string, ca string) (*clientv3.Client, error) {
-	var tlscfg *tls.Config
-	if certfile != "" {
-		cert, err := tls.LoadX509KeyPair(certfile, keyfile)
-		if err != nil {
-			return nil, err
-		}
-		tlscfg = &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: false,
-			Certificates:       []tls.Certificate{cert},
-		}
-		if ca != "" {
-			caCert, err := ioutil.ReadFile(ca)
-			if err != nil {
-				return nil, err
-			}
-			caPool := x509.NewCertPool()
-			if ok := caPool.AppendCertsFromPEM(caCert); !ok {
-				return nil, fmt.Errorf("can't read PEM-formatted certificates from file %s as root CA pool", ca)
-			}
-			tlscfg.RootCAs = caPool
-		}
+func newClient(cluster Cluster) (*clientv3.Client, error) {
+	tls, err := cluster.AuthOptions().TLSConfig()
+	if err != nil {
+		return nil, err
 	}
-	return clientv3.New(clientv3.Config{Endpoints: endpoints, TLS: tlscfg})
+
+	return clientv3.New(clientv3.Config{Endpoints: cluster.Endpoints(), TLS: tls})
 }
 
 func (c *csclient) cacheFileFn(extraFields ...string) cacheFileForZoneFn {

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -241,7 +241,7 @@ func (c *csclient) etcdClientGen(zone string) (*clientv3.Client, error) {
 }
 
 func newClient(cluster Cluster) (*clientv3.Client, error) {
-	tls, err := cluster.AuthOptions().TLSConfig()
+	tls, err := cluster.TLSOptions().Config()
 	if err != nil {
 		return nil, err
 	}

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -279,11 +279,11 @@ func testOptions() Options {
 		NewCluster().SetZone("zone1").SetEndpoints([]string{"i1"}),
 		NewCluster().SetZone("zone2").SetEndpoints([]string{"i2"}),
 		NewCluster().SetZone("zone3").SetEndpoints([]string{"i3"}).
-			SetAuthOptions(NewAuthOptions().SetCert("foo.crt.pem")),
+			SetTLSOptions(NewTLSOptions().SetCrtPath("foo.crt.pem")),
 		NewCluster().SetZone("zone4").SetEndpoints([]string{"i4"}).
-			SetAuthOptions(NewAuthOptions().SetCert("foo.crt.pem").SetKey("foo.key.pem")),
+			SetTLSOptions(NewTLSOptions().SetCrtPath("foo.crt.pem").SetKeyPath("foo.key.pem")),
 		NewCluster().SetZone("zone5").SetEndpoints([]string{"i5"}).
-			SetAuthOptions(NewAuthOptions().SetCert("foo.crt.pem").SetKey("foo.key.pem").SetCA("foo_ca.pem")),
+			SetTLSOptions(NewTLSOptions().SetCrtPath("foo.crt.pem").SetKeyPath("foo.key.pem").SetCACrtPath("foo_ca.pem")),
 	}).SetService("test_app").SetZone("zone1")
 }
 

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -279,11 +279,11 @@ func testOptions() Options {
 		NewCluster().SetZone("zone1").SetEndpoints([]string{"i1"}),
 		NewCluster().SetZone("zone2").SetEndpoints([]string{"i2"}),
 		NewCluster().SetZone("zone3").SetEndpoints([]string{"i3"}).
-			SetCert("foo.crt.pem"),
+			SetAuthOptions(NewAuthOptions().SetCert("foo.crt.pem")),
 		NewCluster().SetZone("zone4").SetEndpoints([]string{"i4"}).
-			SetCert("foo.crt.pem").SetKey("foo.key.pem"),
+			SetAuthOptions(NewAuthOptions().SetCert("foo.crt.pem").SetKey("foo.key.pem")),
 		NewCluster().SetZone("zone5").SetEndpoints([]string{"i5"}).
-			SetCert("foo.crt.pem").SetKey("foo.key.pem").SetCA("foo_ca.pem"),
+			SetAuthOptions(NewAuthOptions().SetCert("foo.crt.pem").SetKey("foo.key.pem").SetCA("foo_ca.pem")),
 	}).SetService("test_app").SetZone("zone1")
 }
 
@@ -291,7 +291,7 @@ func testNewETCDFn(t *testing.T) (newClientFn, func()) {
 	ecluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
 	ec := ecluster.RandClient()
 
-	newFn := func(endpoints []string, cert string, key string, ca string) (*clientv3.Client, error) {
+	newFn := func(Cluster) (*clientv3.Client, error) {
 		return ec, nil
 	}
 

--- a/client/etcd/config.go
+++ b/client/etcd/config.go
@@ -28,23 +28,23 @@ import (
 
 // ClusterConfig is the config for a zoned etcd cluster.
 type ClusterConfig struct {
-	Zone      string     `yaml:"zone"`
-	Endpoints []string   `yaml:"endpoints"`
-	Auth      AuthConfig `yaml:"auth"`
+	Zone      string    `yaml:"zone"`
+	Endpoints []string  `yaml:"endpoints"`
+	TLS       TLSConfig `yaml:"auth"`
 }
 
-// AuthConfig is the config for authentication.
-type AuthConfig struct {
-	Cert string `yaml:"cert"`
-	Key  string `yaml:"key"`
-	CA   string `yaml:"ca"`
+// TLSConfig is the config for TLS.
+type TLSConfig struct {
+	CrtPath   string `yaml:"crtPath"`
+	CACrtPath string `yaml:"caCrtPath"`
+	KeyPath   string `yaml:"keyPath"`
 }
 
-func (c AuthConfig) newOptions() AuthOptions {
-	return NewAuthOptions().
-		SetCert(c.Cert).
-		SetKey(c.Key).
-		SetCA(c.CA)
+func (c TLSConfig) newOptions() TLSOptions {
+	return NewTLSOptions().
+		SetCrtPath(c.CrtPath).
+		SetKeyPath(c.KeyPath).
+		SetCACrtPath(c.CACrtPath)
 }
 
 // Configuration is for config service client.
@@ -79,7 +79,7 @@ func (cfg Configuration) etcdClusters() []Cluster {
 		res[i] = NewCluster().
 			SetZone(c.Zone).
 			SetEndpoints(c.Endpoints).
-			SetAuthOptions(c.Auth.newOptions())
+			SetTLSOptions(c.TLS.newOptions())
 	}
 
 	return res

--- a/client/etcd/config.go
+++ b/client/etcd/config.go
@@ -28,9 +28,9 @@ import (
 
 // ClusterConfig is the config for a zoned etcd cluster.
 type ClusterConfig struct {
-	Zone      string    `yaml:"zone"`
-	Endpoints []string  `yaml:"endpoints"`
-	TLS       TLSConfig `yaml:"tls"`
+	Zone      string     `yaml:"zone"`
+	Endpoints []string   `yaml:"endpoints"`
+	TLS       *TLSConfig `yaml:"tls"`
 }
 
 // TLSConfig is the config for TLS.
@@ -40,11 +40,15 @@ type TLSConfig struct {
 	KeyPath   string `yaml:"keyPath"`
 }
 
-func (c TLSConfig) newOptions() TLSOptions {
-	return NewTLSOptions().
-		SetCrtPath(c.CrtPath).
-		SetKeyPath(c.KeyPath).
-		SetCACrtPath(c.CACrtPath)
+func newTLSOptions(c *TLSConfig) TLSOptions {
+	opts := NewTLSOptions()
+	if c != nil {
+		opts = opts.
+			SetCrtPath(c.CrtPath).
+			SetKeyPath(c.KeyPath).
+			SetCACrtPath(c.CACrtPath)
+	}
+	return opts
 }
 
 // Configuration is for config service client.
@@ -79,7 +83,7 @@ func (cfg Configuration) etcdClusters() []Cluster {
 		res[i] = NewCluster().
 			SetZone(c.Zone).
 			SetEndpoints(c.Endpoints).
-			SetTLSOptions(c.TLS.newOptions())
+			SetTLSOptions(newTLSOptions(c.TLS))
 	}
 
 	return res

--- a/client/etcd/config.go
+++ b/client/etcd/config.go
@@ -30,7 +30,7 @@ import (
 type ClusterConfig struct {
 	Zone      string    `yaml:"zone"`
 	Endpoints []string  `yaml:"endpoints"`
-	TLS       TLSConfig `yaml:"auth"`
+	TLS       TLSConfig `yaml:"tls"`
 }
 
 // TLSConfig is the config for TLS.

--- a/client/etcd/config.go
+++ b/client/etcd/config.go
@@ -42,13 +42,14 @@ type TLSConfig struct {
 
 func newTLSOptions(c *TLSConfig) TLSOptions {
 	opts := NewTLSOptions()
-	if c != nil {
-		opts = opts.
-			SetCrtPath(c.CrtPath).
-			SetKeyPath(c.KeyPath).
-			SetCACrtPath(c.CACrtPath)
+	if c == nil {
+		return opts
 	}
-	return opts
+
+	return opts.
+		SetCrtPath(c.CrtPath).
+		SetKeyPath(c.KeyPath).
+		SetCACrtPath(c.CACrtPath)
 }
 
 // Configuration is for config service client.

--- a/client/etcd/config.go
+++ b/client/etcd/config.go
@@ -40,7 +40,7 @@ type TLSConfig struct {
 	KeyPath   string `yaml:"keyPath"`
 }
 
-func newTLSOptions(c *TLSConfig) TLSOptions {
+func (c *TLSConfig) newOptions() TLSOptions {
 	opts := NewTLSOptions()
 	if c == nil {
 		return opts
@@ -84,7 +84,7 @@ func (cfg Configuration) etcdClusters() []Cluster {
 		res[i] = NewCluster().
 			SetZone(c.Zone).
 			SetEndpoints(c.Endpoints).
-			SetTLSOptions(newTLSOptions(c.TLS))
+			SetTLSOptions(c.TLS.newOptions())
 	}
 
 	return res

--- a/client/etcd/config_test.go
+++ b/client/etcd/config_test.go
@@ -45,15 +45,17 @@ const testConfig = `
           endpoints:
               - etcd3:2379
               - etcd4:2379
-          cert: foo.crt.pem
-          key: foo.key.pem
+          auth:
+            cert: foo.crt.pem
+            key: foo.key.pem
         - zone: z3
           endpoints:
               - etcd5:2379
               - etcd6:2379
-          cert: foo.crt.pem
-          key: foo.key.pem
-          ca: foo_ca.pem
+          auth:
+            cert: foo.crt.pem
+            key: foo.key.pem
+            ca: foo_ca.pem
     m3sd:
         initTimeout: 10s
 `
@@ -74,15 +76,19 @@ func TestConfig(t *testing.T) {
 		ClusterConfig{
 			Zone:      "z2",
 			Endpoints: []string{"etcd3:2379", "etcd4:2379"},
-			Cert:      "foo.crt.pem",
-			Key:       "foo.key.pem",
+			Auth: AuthConfig{
+				Cert: "foo.crt.pem",
+				Key:  "foo.key.pem",
+			},
 		},
 		ClusterConfig{
 			Zone:      "z3",
 			Endpoints: []string{"etcd5:2379", "etcd6:2379"},
-			Cert:      "foo.crt.pem",
-			Key:       "foo.key.pem",
-			CA:        "foo_ca.pem",
+			Auth: AuthConfig{
+				Cert: "foo.crt.pem",
+				Key:  "foo.key.pem",
+				CA:   "foo_ca.pem",
+			},
 		},
 	}, cfg.ETCDClusters)
 	require.Equal(t, 10*time.Second, cfg.SDConfig.InitTimeout)

--- a/client/etcd/config_test.go
+++ b/client/etcd/config_test.go
@@ -76,7 +76,7 @@ func TestConfig(t *testing.T) {
 		ClusterConfig{
 			Zone:      "z2",
 			Endpoints: []string{"etcd3:2379", "etcd4:2379"},
-			TLS: TLSConfig{
+			TLS: &TLSConfig{
 				CrtPath: "foo.crt.pem",
 				KeyPath: "foo.key.pem",
 			},
@@ -84,7 +84,7 @@ func TestConfig(t *testing.T) {
 		ClusterConfig{
 			Zone:      "z3",
 			Endpoints: []string{"etcd5:2379", "etcd6:2379"},
-			TLS: TLSConfig{
+			TLS: &TLSConfig{
 				CrtPath:   "foo.crt.pem",
 				KeyPath:   "foo.key.pem",
 				CACrtPath: "foo_ca.pem",

--- a/client/etcd/config_test.go
+++ b/client/etcd/config_test.go
@@ -45,17 +45,17 @@ const testConfig = `
           endpoints:
               - etcd3:2379
               - etcd4:2379
-          auth:
-            cert: foo.crt.pem
-            key: foo.key.pem
+          tls:
+            crtPath: foo.crt.pem
+            keyPath: foo.key.pem
         - zone: z3
           endpoints:
               - etcd5:2379
               - etcd6:2379
-          auth:
-            cert: foo.crt.pem
-            key: foo.key.pem
-            ca: foo_ca.pem
+          tls:
+            crtPath: foo.crt.pem
+            keyPath: foo.key.pem
+            caCrtPath: foo_ca.pem
     m3sd:
         initTimeout: 10s
 `
@@ -76,18 +76,18 @@ func TestConfig(t *testing.T) {
 		ClusterConfig{
 			Zone:      "z2",
 			Endpoints: []string{"etcd3:2379", "etcd4:2379"},
-			Auth: AuthConfig{
-				Cert: "foo.crt.pem",
-				Key:  "foo.key.pem",
+			TLS: TLSConfig{
+				CrtPath: "foo.crt.pem",
+				KeyPath: "foo.key.pem",
 			},
 		},
 		ClusterConfig{
 			Zone:      "z3",
 			Endpoints: []string{"etcd5:2379", "etcd6:2379"},
-			Auth: AuthConfig{
-				Cert: "foo.crt.pem",
-				Key:  "foo.key.pem",
-				CA:   "foo_ca.pem",
+			TLS: TLSConfig{
+				CrtPath:   "foo.crt.pem",
+				KeyPath:   "foo.key.pem",
+				CACrtPath: "foo_ca.pem",
 			},
 		},
 	}, cfg.ETCDClusters)

--- a/client/etcd/options.go
+++ b/client/etcd/options.go
@@ -68,29 +68,29 @@ func (o tlsOptions) SetCACrtPath(ca string) TLSOptions {
 }
 
 func (o tlsOptions) Config() (*tls.Config, error) {
-	if o.cert != "" {
-		cert, err := tls.LoadX509KeyPair(o.cert, o.key)
-		if err != nil {
-			return nil, err
-		}
-		caCert, err := ioutil.ReadFile(o.ca)
-		if err != nil {
-			return nil, err
-		}
-		caPool := x509.NewCertPool()
-		if ok := caPool.AppendCertsFromPEM(caCert); !ok {
-			return nil, fmt.Errorf("can't read PEM-formatted certificates from file %s as root CA pool", o.ca)
-		}
-		return &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: false,
-			Certificates:       []tls.Certificate{cert},
-			RootCAs:            caPool,
-		}, nil
+	if o.cert == "" {
+		// By default we should use nil config instead of empty config.
+		return nil, nil
 	}
 
-	// By default we should use nil config instead of empty config.
-	return nil, nil
+	cert, err := tls.LoadX509KeyPair(o.cert, o.key)
+	if err != nil {
+		return nil, err
+	}
+	caCert, err := ioutil.ReadFile(o.ca)
+	if err != nil {
+		return nil, err
+	}
+	caPool := x509.NewCertPool()
+	if ok := caPool.AppendCertsFromPEM(caCert); !ok {
+		return nil, fmt.Errorf("can't read PEM-formatted certificates from file %s as root CA pool", o.ca)
+	}
+	return &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: false,
+		Certificates:       []tls.Certificate{cert},
+		RootCAs:            caPool,
+	}, nil
 }
 
 // NewOptions creates a set of Options.

--- a/client/etcd/options.go
+++ b/client/etcd/options.go
@@ -68,30 +68,29 @@ func (o tlsOptions) SetCACrtPath(ca string) TLSOptions {
 }
 
 func (o tlsOptions) Config() (*tls.Config, error) {
-	var tlscfg *tls.Config
 	if o.cert != "" {
 		cert, err := tls.LoadX509KeyPair(o.cert, o.key)
 		if err != nil {
 			return nil, err
 		}
-		tlscfg = &tls.Config{
+		caCert, err := ioutil.ReadFile(o.ca)
+		if err != nil {
+			return nil, err
+		}
+		caPool := x509.NewCertPool()
+		if ok := caPool.AppendCertsFromPEM(caCert); !ok {
+			return nil, fmt.Errorf("can't read PEM-formatted certificates from file %s as root CA pool", o.ca)
+		}
+		return &tls.Config{
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: false,
 			Certificates:       []tls.Certificate{cert},
-		}
-		if o.ca != "" {
-			caCert, err := ioutil.ReadFile(o.ca)
-			if err != nil {
-				return nil, err
-			}
-			caPool := x509.NewCertPool()
-			if ok := caPool.AppendCertsFromPEM(caCert); !ok {
-				return nil, fmt.Errorf("can't read PEM-formatted certificates from file %s as root CA pool", o.ca)
-			}
-			tlscfg.RootCAs = caPool
-		}
+			RootCAs:            caPool,
+		}, nil
 	}
-	return tlscfg, nil
+
+	// By default we should use nil config instead of empty config.
+	return nil, nil
 }
 
 // NewOptions creates a set of Options.

--- a/client/etcd/options.go
+++ b/client/etcd/options.go
@@ -33,44 +33,44 @@ import (
 
 // NewTLSOptions creates a set of TLS Options.
 func NewTLSOptions() TLSOptions {
-	return authOptions{}
+	return tlsOptions{}
 }
 
-type authOptions struct {
+type tlsOptions struct {
 	cert string
 	key  string
 	ca   string
 }
 
-func (c authOptions) CrtPath() string {
-	return c.cert
+func (o tlsOptions) CrtPath() string {
+	return o.cert
 }
 
-func (c authOptions) SetCrtPath(cert string) TLSOptions {
-	c.cert = cert
-	return c
+func (o tlsOptions) SetCrtPath(cert string) TLSOptions {
+	o.cert = cert
+	return o
 }
 
-func (c authOptions) KeyPath() string {
-	return c.key
+func (o tlsOptions) KeyPath() string {
+	return o.key
 }
-func (c authOptions) SetKeyPath(key string) TLSOptions {
-	c.key = key
-	return c
-}
-
-func (c authOptions) CACrtPath() string {
-	return c.ca
-}
-func (c authOptions) SetCACrtPath(ca string) TLSOptions {
-	c.ca = ca
-	return c
+func (o tlsOptions) SetKeyPath(key string) TLSOptions {
+	o.key = key
+	return o
 }
 
-func (c authOptions) Config() (*tls.Config, error) {
+func (o tlsOptions) CACrtPath() string {
+	return o.ca
+}
+func (o tlsOptions) SetCACrtPath(ca string) TLSOptions {
+	o.ca = ca
+	return o
+}
+
+func (o tlsOptions) Config() (*tls.Config, error) {
 	var tlscfg *tls.Config
-	if c.cert != "" {
-		cert, err := tls.LoadX509KeyPair(c.cert, c.key)
+	if o.cert != "" {
+		cert, err := tls.LoadX509KeyPair(o.cert, o.key)
 		if err != nil {
 			return nil, err
 		}
@@ -79,14 +79,14 @@ func (c authOptions) Config() (*tls.Config, error) {
 			InsecureSkipVerify: false,
 			Certificates:       []tls.Certificate{cert},
 		}
-		if c.ca != "" {
-			caCert, err := ioutil.ReadFile(c.ca)
+		if o.ca != "" {
+			caCert, err := ioutil.ReadFile(o.ca)
 			if err != nil {
 				return nil, err
 			}
 			caPool := x509.NewCertPool()
 			if ok := caPool.AppendCertsFromPEM(caCert); !ok {
-				return nil, fmt.Errorf("can't read PEM-formatted certificates from file %s as root CA pool", c.ca)
+				return nil, fmt.Errorf("can't read PEM-formatted certificates from file %s as root CA pool", o.ca)
 			}
 			tlscfg.RootCAs = caPool
 		}
@@ -202,13 +202,13 @@ func (o options) SetInstrumentOptions(iopts instrument.Options) Options {
 
 // NewCluster creates a Cluster.
 func NewCluster() Cluster {
-	return cluster{aOpts: NewTLSOptions()}
+	return cluster{tlsOpts: NewTLSOptions()}
 }
 
 type cluster struct {
 	zone      string
 	endpoints []string
-	aOpts     TLSOptions
+	tlsOpts   TLSOptions
 }
 
 func (c cluster) Zone() string {
@@ -230,10 +230,10 @@ func (c cluster) SetEndpoints(endpoints []string) Cluster {
 }
 
 func (c cluster) TLSOptions() TLSOptions {
-	return c.aOpts
+	return c.tlsOpts
 }
 
 func (c cluster) SetTLSOptions(opts TLSOptions) Cluster {
-	c.aOpts = opts
+	c.tlsOpts = opts
 	return c
 }

--- a/client/etcd/options.go
+++ b/client/etcd/options.go
@@ -31,8 +31,8 @@ import (
 	"github.com/m3db/m3x/instrument"
 )
 
-// NewAuthOptions creates a set of Auth Options.
-func NewAuthOptions() AuthOptions {
+// NewTLSOptions creates a set of TLS Options.
+func NewTLSOptions() TLSOptions {
 	return authOptions{}
 }
 
@@ -42,32 +42,32 @@ type authOptions struct {
 	ca   string
 }
 
-func (c authOptions) Cert() string {
+func (c authOptions) CrtPath() string {
 	return c.cert
 }
 
-func (c authOptions) SetCert(cert string) AuthOptions {
+func (c authOptions) SetCrtPath(cert string) TLSOptions {
 	c.cert = cert
 	return c
 }
 
-func (c authOptions) Key() string {
+func (c authOptions) KeyPath() string {
 	return c.key
 }
-func (c authOptions) SetKey(key string) AuthOptions {
+func (c authOptions) SetKeyPath(key string) TLSOptions {
 	c.key = key
 	return c
 }
 
-func (c authOptions) CA() string {
+func (c authOptions) CACrtPath() string {
 	return c.ca
 }
-func (c authOptions) SetCA(ca string) AuthOptions {
+func (c authOptions) SetCACrtPath(ca string) TLSOptions {
 	c.ca = ca
 	return c
 }
 
-func (c authOptions) TLSConfig() (*tls.Config, error) {
+func (c authOptions) Config() (*tls.Config, error) {
 	var tlscfg *tls.Config
 	if c.cert != "" {
 		cert, err := tls.LoadX509KeyPair(c.cert, c.key)
@@ -202,13 +202,13 @@ func (o options) SetInstrumentOptions(iopts instrument.Options) Options {
 
 // NewCluster creates a Cluster.
 func NewCluster() Cluster {
-	return cluster{aOpts: NewAuthOptions()}
+	return cluster{aOpts: NewTLSOptions()}
 }
 
 type cluster struct {
 	zone      string
 	endpoints []string
-	aOpts     AuthOptions
+	aOpts     TLSOptions
 }
 
 func (c cluster) Zone() string {
@@ -229,11 +229,11 @@ func (c cluster) SetEndpoints(endpoints []string) Cluster {
 	return c
 }
 
-func (c cluster) AuthOptions() AuthOptions {
+func (c cluster) TLSOptions() TLSOptions {
 	return c.aOpts
 }
 
-func (c cluster) SetAuthOptions(opts AuthOptions) Cluster {
+func (c cluster) SetTLSOptions(opts TLSOptions) Cluster {
 	c.aOpts = opts
 	return c
 }

--- a/client/etcd/options_test.go
+++ b/client/etcd/options_test.go
@@ -51,7 +51,7 @@ func TestCluster(t *testing.T) {
 	assert.Equal(t, aOpts, c.TLSOptions())
 }
 
-func TestAuthOptions(t *testing.T) {
+func TestTLSOptions(t *testing.T) {
 	aOpts := NewTLSOptions()
 	assert.Equal(t, "", aOpts.CrtPath())
 	assert.Equal(t, "", aOpts.KeyPath())

--- a/client/etcd/options_test.go
+++ b/client/etcd/options_test.go
@@ -34,34 +34,34 @@ func TestCluster(t *testing.T) {
 	c := NewCluster()
 	assert.Equal(t, "", c.Zone())
 	assert.Equal(t, 0, len(c.Endpoints()))
-	assert.Equal(t, "", c.Cert())
-	assert.Equal(t, "", c.Key())
+	assert.Equal(t, NewAuthOptions(), c.AuthOptions())
 
 	c = c.SetZone("z")
 	assert.Equal(t, "z", c.Zone())
 	assert.Equal(t, 0, len(c.Endpoints()))
-	assert.Equal(t, "", c.Cert())
-	assert.Equal(t, "", c.Key())
 
 	c = c.SetEndpoints([]string{"e1"})
 	assert.Equal(t, "z", c.Zone())
 	assert.Equal(t, []string{"e1"}, c.Endpoints())
-	assert.Equal(t, "", c.Cert())
-	assert.Equal(t, "", c.Key())
 
-	c = c.SetCert("self.crt.pem")
+	aOpts := NewAuthOptions().SetCert("cert").SetKey("key").SetCA("ca")
+	c = c.SetAuthOptions(aOpts)
 	assert.Equal(t, "z", c.Zone())
 	assert.Equal(t, []string{"e1"}, c.Endpoints())
-	assert.Equal(t, "self.crt.pem", c.Cert())
-	assert.Equal(t, "", c.Key())
-
-	c = c.SetKey("self.key.pem")
-	assert.Equal(t, "z", c.Zone())
-	assert.Equal(t, []string{"e1"}, c.Endpoints())
-	assert.Equal(t, "self.crt.pem", c.Cert())
-	assert.Equal(t, "self.key.pem", c.Key())
+	assert.Equal(t, aOpts, c.AuthOptions())
 }
 
+func TestAuthOptions(t *testing.T) {
+	aOpts := NewAuthOptions()
+	assert.Equal(t, "", aOpts.Cert())
+	assert.Equal(t, "", aOpts.Key())
+	assert.Equal(t, "", aOpts.CA())
+
+	aOpts = aOpts.SetCert("cert").SetKey("key").SetCA("ca")
+	assert.Equal(t, "cert", aOpts.Cert())
+	assert.Equal(t, "key", aOpts.Key())
+	assert.Equal(t, "ca", aOpts.CA())
+}
 func TestOptions(t *testing.T) {
 	opts := NewOptions()
 	assert.Equal(t, "", opts.Zone())

--- a/client/etcd/options_test.go
+++ b/client/etcd/options_test.go
@@ -34,7 +34,7 @@ func TestCluster(t *testing.T) {
 	c := NewCluster()
 	assert.Equal(t, "", c.Zone())
 	assert.Equal(t, 0, len(c.Endpoints()))
-	assert.Equal(t, NewAuthOptions(), c.AuthOptions())
+	assert.Equal(t, NewTLSOptions(), c.TLSOptions())
 
 	c = c.SetZone("z")
 	assert.Equal(t, "z", c.Zone())
@@ -44,23 +44,23 @@ func TestCluster(t *testing.T) {
 	assert.Equal(t, "z", c.Zone())
 	assert.Equal(t, []string{"e1"}, c.Endpoints())
 
-	aOpts := NewAuthOptions().SetCert("cert").SetKey("key").SetCA("ca")
-	c = c.SetAuthOptions(aOpts)
+	aOpts := NewTLSOptions().SetCrtPath("cert").SetKeyPath("key").SetCACrtPath("ca")
+	c = c.SetTLSOptions(aOpts)
 	assert.Equal(t, "z", c.Zone())
 	assert.Equal(t, []string{"e1"}, c.Endpoints())
-	assert.Equal(t, aOpts, c.AuthOptions())
+	assert.Equal(t, aOpts, c.TLSOptions())
 }
 
 func TestAuthOptions(t *testing.T) {
-	aOpts := NewAuthOptions()
-	assert.Equal(t, "", aOpts.Cert())
-	assert.Equal(t, "", aOpts.Key())
-	assert.Equal(t, "", aOpts.CA())
+	aOpts := NewTLSOptions()
+	assert.Equal(t, "", aOpts.CrtPath())
+	assert.Equal(t, "", aOpts.KeyPath())
+	assert.Equal(t, "", aOpts.CACrtPath())
 
-	aOpts = aOpts.SetCert("cert").SetKey("key").SetCA("ca")
-	assert.Equal(t, "cert", aOpts.Cert())
-	assert.Equal(t, "key", aOpts.Key())
-	assert.Equal(t, "ca", aOpts.CA())
+	aOpts = aOpts.SetCrtPath("cert").SetKeyPath("key").SetCACrtPath("ca")
+	assert.Equal(t, "cert", aOpts.CrtPath())
+	assert.Equal(t, "key", aOpts.KeyPath())
+	assert.Equal(t, "ca", aOpts.CACrtPath())
 }
 func TestOptions(t *testing.T) {
 	opts := NewOptions()

--- a/client/etcd/types.go
+++ b/client/etcd/types.go
@@ -27,7 +27,7 @@ import (
 	"github.com/m3db/m3x/instrument"
 )
 
-// Options is the Options to create a config service client
+// Options is the Options to create a config service client.
 type Options interface {
 	Env() string
 	SetEnv(e string) Options

--- a/client/etcd/types.go
+++ b/client/etcd/types.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package etcd
+
+import (
+	"crypto/tls"
+
+	etcdsd "github.com/m3db/m3cluster/services/client/etcd"
+	"github.com/m3db/m3x/instrument"
+)
+
+// Options is the Options to create a config service client
+type Options interface {
+	Env() string
+	SetEnv(e string) Options
+
+	Zone() string
+	SetZone(z string) Options
+
+	Service() string
+	SetService(id string) Options
+
+	CacheDir() string
+	SetCacheDir(dir string) Options
+
+	ServiceDiscoveryConfig() etcdsd.Configuration
+	SetServiceDiscoveryConfig(cfg etcdsd.Configuration) Options
+
+	Clusters() []Cluster
+	SetClusters(clusters []Cluster) Options
+	ClusterForZone(z string) (Cluster, bool)
+
+	InstrumentOptions() instrument.Options
+	SetInstrumentOptions(iopts instrument.Options) Options
+
+	Validate() error
+}
+
+// AuthOptions defines the configuration for authentication.
+type AuthOptions interface {
+	Cert() string
+	SetCert(string) AuthOptions
+
+	Key() string
+	SetKey(string) AuthOptions
+
+	CA() string
+	SetCA(string) AuthOptions
+
+	TLSConfig() (*tls.Config, error)
+}
+
+// Cluster defines the configuration for a etcd cluster.
+type Cluster interface {
+	Zone() string
+	SetZone(z string) Cluster
+
+	Endpoints() []string
+	SetEndpoints(endpoints []string) Cluster
+
+	AuthOptions() AuthOptions
+	SetAuthOptions(AuthOptions) Cluster
+}

--- a/client/etcd/types.go
+++ b/client/etcd/types.go
@@ -54,18 +54,18 @@ type Options interface {
 	Validate() error
 }
 
-// AuthOptions defines the configuration for authentication.
-type AuthOptions interface {
-	Cert() string
-	SetCert(string) AuthOptions
+// TLSOptions defines the configuration for TLS.
+type TLSOptions interface {
+	CrtPath() string
+	SetCrtPath(string) TLSOptions
 
-	Key() string
-	SetKey(string) AuthOptions
+	KeyPath() string
+	SetKeyPath(string) TLSOptions
 
-	CA() string
-	SetCA(string) AuthOptions
+	CACrtPath() string
+	SetCACrtPath(string) TLSOptions
 
-	TLSConfig() (*tls.Config, error)
+	Config() (*tls.Config, error)
 }
 
 // Cluster defines the configuration for a etcd cluster.
@@ -76,6 +76,6 @@ type Cluster interface {
 	Endpoints() []string
 	SetEndpoints(endpoints []string) Cluster
 
-	AuthOptions() AuthOptions
-	SetAuthOptions(AuthOptions) Cluster
+	TLSOptions() TLSOptions
+	SetTLSOptions(TLSOptions) Cluster
 }


### PR DESCRIPTION
Refactor the logic around auth to keep the tls related logic isolated from etcd cluster logic

@xichen2020 @prateek @jeromefroe 