### PR TITLE
Use logger in config service client as default logger for kv client

### DIFF
--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -110,11 +110,7 @@ func (c *csclient) KV() (kv.Store, error) {
 
 func (c *csclient) Txn() (kv.TxnStore, error) {
 	c.txnOnce.Do(func() {
-		kvOpts := kv.NewOptions().
-			SetNamespace(kvPrefix).
-			SetEnvironment(c.opts.Env()).
-			SetLogger(c.logger)
-		c.txn, c.txnErr = c.TxnStore(kvOpts)
+		c.txn, c.txnErr = c.TxnStore(kv.NewOptions())
 	})
 	return c.txn, c.txnErr
 }

--- a/client/etcd/client.go
+++ b/client/etcd/client.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync"
 
@@ -309,7 +308,7 @@ func validateTopLevelNamespace(namespace string) error {
 }
 
 func (c *csclient) sanitizeOptions(opts kv.Options) (kv.Options, error) {
-	if opts.Logger() == nil || reflect.DeepEqual(opts.Logger(), log.NullLogger) {
+	if logger := opts.Logger(); logger == nil || logger == log.NullLogger {
 		opts = opts.SetLogger(c.logger)
 	}
 

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -221,6 +221,20 @@ func TestCacheFileForZone(t *testing.T) {
 	require.Equal(t, "/cacheDir/test_app_z1__r2_m3agg.json", kvOpts.CacheFileFn()(kvOpts.Prefix()))
 }
 
+func TestSanitizeKVOptions(t *testing.T) {
+	opts := testOptions()
+	cs, err := NewConfigServiceClient(opts)
+	require.NoError(t, err)
+
+	kvOpts := kv.NewOptions()
+	require.NotEqual(t, opts.InstrumentOptions().Logger(), kvOpts.Logger())
+
+	kvOpts, err = cs.(*csclient).sanitizeOptions(kvOpts)
+	require.NoError(t, err)
+	require.NoError(t, kvOpts.Validate())
+	require.Equal(t, opts.InstrumentOptions().Logger(), kvOpts.Logger())
+}
+
 func TestValidateNamespace(t *testing.T) {
 	inputs := []struct {
 		ns        string

--- a/client/etcd/client_test.go
+++ b/client/etcd/client_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/m3db/m3cluster/kv"
 	"github.com/m3db/m3cluster/services"
+	"github.com/m3db/m3x/log"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/integration"
@@ -227,12 +228,18 @@ func TestSanitizeKVOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	kvOpts := kv.NewOptions()
-	require.NotEqual(t, opts.InstrumentOptions().Logger(), kvOpts.Logger())
-
 	kvOpts, err = cs.(*csclient).sanitizeOptions(kvOpts)
 	require.NoError(t, err)
 	require.NoError(t, kvOpts.Validate())
+	require.Equal(t, kvPrefix, kvOpts.Namespace())
+	require.Equal(t, opts.Env(), kvOpts.Environment())
 	require.Equal(t, opts.InstrumentOptions().Logger(), kvOpts.Logger())
+
+	kvOpts = kv.NewOptions().SetLogger(log.NewLevelLogger(log.SimpleLogger, log.LevelWarn))
+	kvOpts, err = cs.(*csclient).sanitizeOptions(kvOpts)
+	require.NoError(t, err)
+	require.NoError(t, kvOpts.Validate())
+	require.NotEqual(t, opts.InstrumentOptions().Logger(), kvOpts.Logger())
 }
 
 func TestValidateNamespace(t *testing.T) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0206ff542af1611b989062b69f6e3f5fbd1a9f79daf37590982bca520990075a
-updated: 2017-09-18T19:54:18.872848253-04:00
+hash: 7e9cd1ae7e5d10c435f2dd24a5574d32c30016e76f9e0781ec30de34ae480915
+updated: 2017-10-22T09:43:09.549193865-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -125,7 +125,7 @@ imports:
 - name: github.com/karlseguin/ccache
   version: a2d62155777b39595c825ed3824279e642a5db3c
 - name: github.com/m3db/m3x
-  version: 6e9713eca6718643e105f574be392f122bcc062e
+  version: e76dc88cb5aac2852e0fa707ceb1dd648f11ad8a
   subpackages:
   - clock
   - close
@@ -172,7 +172,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
-  version: be9e53c77349ae2dd4b8c03a6dc20ed9a88b9927
+  version: 95078a8f10668bd1fa73ae46761cdc58d25436b8
   subpackages:
   - m3
   - m3/customtransports

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7e9cd1ae7e5d10c435f2dd24a5574d32c30016e76f9e0781ec30de34ae480915
-updated: 2017-10-22T09:43:09.549193865-04:00
+hash: c27c440c81f4b6b98930dfcd460482c78b707d2f680a2437af1edee497f81ee2
+updated: 2017-10-25T12:00:11.806233583-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -125,7 +125,7 @@ imports:
 - name: github.com/karlseguin/ccache
   version: a2d62155777b39595c825ed3824279e642a5db3c
 - name: github.com/m3db/m3x
-  version: e76dc88cb5aac2852e0fa707ceb1dd648f11ad8a
+  version: 515e3030818e6dab3fd418f05b96174ae4c527df
   subpackages:
   - clock
   - close
@@ -209,8 +209,6 @@ imports:
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
   repo: https://github.com/golang/sys
   vcs: git
-  subpackages:
-  - unix
 - name: golang.org/x/time
   version: a4bde12657593d5e90d0533a3e4fd95e635124cb
   repo: https://github.com/golang/time

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,7 +16,7 @@ import:
   subpackages:
   - proto
 - package: github.com/m3db/m3x
-  version: 6e9713eca6718643e105f574be392f122bcc062e
+  version: e76dc88cb5aac2852e0fa707ceb1dd648f11ad8a
 - package: github.com/prometheus/client_model
   version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
 - package: github.com/prometheus/common

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,7 +16,7 @@ import:
   subpackages:
   - proto
 - package: github.com/m3db/m3x
-  version: e76dc88cb5aac2852e0fa707ceb1dd648f11ad8a
+  version: 515e3030818e6dab3fd418f05b96174ae4c527df
 - package: github.com/prometheus/client_model
   version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
 - package: github.com/prometheus/common


### PR DESCRIPTION
Seems current logic means the kv client in m3db will be using nulllogger as well, we probably need to upgrade all repos with this change, seems the only place with a real logger with the previous version is the one in m3aggregator where we explicitly set a logger with Warn level.

@robskillington @xichen2020 @prateek @jeromefroe 