### PR TITLE
Add MarkAllShardsAvailable to mark initializing shards available where applicable

### DIFF
--- a/placement/algo/mirrored.go
+++ b/placement/algo/mirrored.go
@@ -80,10 +80,11 @@ func (a mirroredAlgorithm) InitialPlacement(
 	}
 
 	// NB(cw): Do not validate shards for initial placement.
-	return markAllShardsAvailable(
+	p, _, err = markAllShardsAvailable(
 		p,
 		a.opts.SetIsShardCutoverFn(nil).SetIsShardCutoffFn(nil),
 	)
+	return p, err
 }
 
 func (a mirroredAlgorithm) AddReplica(p placement.Placement) (placement.Placement, error) {
@@ -107,7 +108,7 @@ func (a mirroredAlgorithm) RemoveInstances(
 		return a.returnInitializingShards(p, instanceIDs)
 	}
 
-	p, err := markAllShardsAvailable(p, a.opts)
+	p, _, err := markAllShardsAvailable(p, a.opts)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (a mirroredAlgorithm) AddInstances(
 		return a.reclaimLeavingShards(p, addingInstances)
 	}
 
-	p, err := markAllShardsAvailable(p, a.opts)
+	p, _, err := markAllShardsAvailable(p, a.opts)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (a mirroredAlgorithm) ReplaceInstances(
 		return a.returnInitializingShards(p, leavingInstanceIDs)
 	}
 
-	if p, err = markAllShardsAvailable(p, a.opts); err != nil {
+	if p, _, err = markAllShardsAvailable(p, a.opts); err != nil {
 		return nil, err
 	}
 
@@ -255,6 +256,16 @@ func (a mirroredAlgorithm) MarkShardAvailable(
 	}
 
 	return a.shardedAlgo.MarkShardAvailable(p, instanceID, shardID)
+}
+
+func (a mirroredAlgorithm) MarkAllShardsAvailable(
+	p placement.Placement,
+) (placement.Placement, bool, error) {
+	if err := a.IsCompatibleWith(p); err != nil {
+		return nil, false, err
+	}
+
+	return a.shardedAlgo.MarkAllShardsAvailable(p)
 }
 
 // allInitializing returns true when

--- a/placement/algo/mirrored.go
+++ b/placement/algo/mirrored.go
@@ -108,7 +108,7 @@ func (a mirroredAlgorithm) RemoveInstances(
 		return a.returnInitializingShards(p, instanceIDs)
 	}
 
-	p, _, err := markAllShardsAvailable(p, a.opts)
+	p, _, err := a.MarkAllShardsAvailable(p)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func (a mirroredAlgorithm) AddInstances(
 		return a.reclaimLeavingShards(p, addingInstances)
 	}
 
-	p, _, err := markAllShardsAvailable(p, a.opts)
+	p, _, err := a.MarkAllShardsAvailable(p)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (a mirroredAlgorithm) ReplaceInstances(
 		return a.returnInitializingShards(p, leavingInstanceIDs)
 	}
 
-	if p, _, err = markAllShardsAvailable(p, a.opts); err != nil {
+	if p, _, err = a.MarkAllShardsAvailable(p); err != nil {
 		return nil, err
 	}
 

--- a/placement/algo/non_sharded.go
+++ b/placement/algo/non_sharded.go
@@ -147,3 +147,13 @@ func (a nonShardedAlgorithm) MarkShardAvailable(
 	// There is no shards in non-sharded algorithm.
 	return p, nil
 }
+
+func (a nonShardedAlgorithm) MarkAllShardsAvailable(
+	p placement.Placement,
+) (placement.Placement, bool, error) {
+	if err := a.IsCompatibleWith(p); err != nil {
+		return nil, false, err
+	}
+	// There is no shards in non-sharded algorithm.
+	return p, false, nil
+}

--- a/placement/algo/sharded.go
+++ b/placement/algo/sharded.go
@@ -72,10 +72,11 @@ func (a rackAwarePlacementAlgorithm) InitialPlacement(
 
 	// NB(r): All new placements should appear as available for
 	// proper client semantics when calculating consistency results
-	return markAllShardsAvailable(
+	p, _, err := markAllShardsAvailable(
 		p,
 		a.opts.SetIsShardCutoverFn(nil).SetIsShardCutoffFn(nil),
 	)
+	return p, err
 }
 
 func (a rackAwarePlacementAlgorithm) AddReplica(p placement.Placement) (placement.Placement, error) {
@@ -212,4 +213,14 @@ func (a rackAwarePlacementAlgorithm) MarkShardAvailable(
 	}
 
 	return markShardAvailable(p.Clone(), instanceID, shardID, a.opts)
+}
+
+func (a rackAwarePlacementAlgorithm) MarkAllShardsAvailable(
+	p placement.Placement,
+) (placement.Placement, bool, error) {
+	if err := a.IsCompatibleWith(p); err != nil {
+		return nil, false, err
+	}
+
+	return markAllShardsAvailable(p, a.opts)
 }

--- a/placement/algo/sharded_helper_test.go
+++ b/placement/algo/sharded_helper_test.go
@@ -524,7 +524,7 @@ func TestMarkAllAsAvailable(t *testing.T) {
 		SetReplicaFactor(2)
 
 	opts := placement.NewOptions()
-	_, err := markAllShardsAvailable(p, opts)
+	_, _, err := markAllShardsAvailable(p, opts)
 	assert.NoError(t, err)
 
 	i2.Shards().Add(shard.NewShard(3).SetState(shard.Initializing).SetSourceID("i3"))
@@ -532,7 +532,7 @@ func TestMarkAllAsAvailable(t *testing.T) {
 		SetInstances([]placement.Instance{i1, i2}).
 		SetShards([]uint32{1, 2}).
 		SetReplicaFactor(2)
-	_, err = markAllShardsAvailable(p, opts)
+	_, _, err = markAllShardsAvailable(p, opts)
 	assert.Contains(t, err.Error(), "does not exist in placement")
 }
 

--- a/placement/algo/sharded_test.go
+++ b/placement/algo/sharded_test.go
@@ -1164,7 +1164,7 @@ func mustMarkAllShardsAsAvailable(t *testing.T, p placement.Placement, opts plac
 	if opts == nil {
 		opts = placement.NewOptions()
 	}
-	p, err := markAllShardsAvailable(p, opts)
+	p, _, err := markAllShardsAvailable(p, opts)
 	require.NoError(t, err)
 	return p
 }

--- a/placement/service/service.go
+++ b/placement/service/service.go
@@ -202,6 +202,27 @@ func (ps *placementService) MarkShardAvailable(instanceID string, shardID uint32
 	return ps.CheckAndSet(p, v)
 }
 
+func (ps *placementService) MarkAllShardsAvailable() (placement.Placement, error) {
+	p, v, err := ps.Placement()
+	if err != nil {
+		return nil, err
+	}
+
+	p, updated, err := ps.algo.MarkAllShardsAvailable(p)
+	if err != nil {
+		return nil, err
+	}
+	if !updated {
+		return p, nil
+	}
+
+	if err := placement.Validate(p); err != nil {
+		return nil, err
+	}
+
+	return p, ps.CheckAndSet(p, v)
+}
+
 func (ps *placementService) MarkInstanceAvailable(instanceID string) error {
 	p, v, err := ps.Placement()
 	if err != nil {

--- a/placement/types.go
+++ b/placement/types.go
@@ -455,6 +455,9 @@ type Service interface {
 	// MarkShardAvailable marks the state of a shard as available.
 	MarkShardAvailable(instanceID string, shardID uint32) error
 
+	// MarkAllShardsAvailable marks shard states as available where applicable.
+	MarkAllShardsAvailable() (Placement, error)
+
 	// MarkInstanceAvailable marks all the shards on a given instance as available.
 	MarkInstanceAvailable(instanceID string) error
 }
@@ -485,6 +488,9 @@ type Algorithm interface {
 
 	// MarkShardAvailable marks a shard as available.
 	MarkShardAvailable(p Placement, instanceID string, shardID uint32) (Placement, error)
+
+	// MarkAllShardsAvailable marks shard states as available where applicable.
+	MarkAllShardsAvailable(p Placement) (Placement, bool, error)
 }
 
 // InstanceSelector selects valid instances for the placement change.


### PR DESCRIPTION
cc @cw9

This PR exposes the `MarkAllShardsAvailable` API to mark all shards available where applicable.