### PR TITLE
Allow replace with less weight in instance selector

### DIFF
--- a/placement/selector/mirrored.go
+++ b/placement/selector/mirrored.go
@@ -34,13 +34,13 @@ var (
 	errNoValidMirrorInstance = errors.New("no valid instance for mirror placement in the candidate list")
 )
 
-type mirroredFilter struct {
+type mirroredSelector struct {
 	opts   placement.Options
 	logger log.Logger
 }
 
 func newMirroredSelector(opts placement.Options) placement.InstanceSelector {
-	return &mirroredFilter{
+	return &mirroredSelector{
 		opts:   opts,
 		logger: opts.InstrumentOptions().Logger(),
 	}
@@ -48,7 +48,7 @@ func newMirroredSelector(opts placement.Options) placement.InstanceSelector {
 
 // SelectInitialInstances tries to make as many groups as possible from
 // the candidate instances to make the initial placement.
-func (f *mirroredFilter) SelectInitialInstances(
+func (f *mirroredSelector) SelectInitialInstances(
 	candidates []placement.Instance,
 	rf int,
 ) ([]placement.Instance, error) {
@@ -91,7 +91,7 @@ func (f *mirroredFilter) SelectInitialInstances(
 
 // SelectAddingInstances tries to make just one group of hosts from
 // the candidate instances to be added to the placement.
-func (f *mirroredFilter) SelectAddingInstances(
+func (f *mirroredSelector) SelectAddingInstances(
 	candidates []placement.Instance,
 	p placement.Placement,
 ) ([]placement.Instance, error) {
@@ -131,7 +131,7 @@ func (f *mirroredFilter) SelectAddingInstances(
 // Two main use cases:
 // 1, find a new host from a pool of hosts to replace a host in the placement.
 // 2, back out of a replacement, both leaving and adding host are still in the placement.
-func (f *mirroredFilter) SelectReplaceInstances(
+func (f *mirroredSelector) SelectReplaceInstances(
 	candidates []placement.Instance,
 	leavingInstanceIDs []string,
 	p placement.Placement,

--- a/placement/selector/non_mirrored.go
+++ b/placement/selector/non_mirrored.go
@@ -34,22 +34,22 @@ var (
 	errNoValidInstance = errors.New("no valid instance in the candidate list")
 )
 
-type nonMirroredFilter struct {
+type nonMirroredSelector struct {
 	opts placement.Options
 }
 
 func newNonMirroredSelector(opts placement.Options) placement.InstanceSelector {
-	return &nonMirroredFilter{opts: opts}
+	return &nonMirroredSelector{opts: opts}
 }
 
-func (f *nonMirroredFilter) SelectInitialInstances(
+func (f *nonMirroredSelector) SelectInitialInstances(
 	candidates []placement.Instance,
 	rf int,
 ) ([]placement.Instance, error) {
 	return getValidCandidates(placement.NewPlacement(), candidates, f.opts)
 }
 
-func (f *nonMirroredFilter) SelectAddingInstances(
+func (f *nonMirroredSelector) SelectAddingInstances(
 	candidates []placement.Instance,
 	p placement.Placement,
 ) ([]placement.Instance, error) {
@@ -94,7 +94,7 @@ func (f *nonMirroredFilter) SelectAddingInstances(
 	return nil, errNoValidInstance
 }
 
-func (f *nonMirroredFilter) SelectReplaceInstances(
+func (f *nonMirroredSelector) SelectReplaceInstances(
 	candidates []placement.Instance,
 	leavingInstanceIDs []string,
 	p placement.Placement,
@@ -144,7 +144,7 @@ func (f *nonMirroredFilter) SelectReplaceInstances(
 	}
 	result, leftWeight := fillWeight(groups, int(totalWeight))
 
-	if leftWeight > 0 {
+	if leftWeight > 0 && !f.opts.AllowPartialReplace() {
 		return nil, fmt.Errorf("could not find enough instance to replace %v, %d weight could not be replaced",
 			leavingInstances, leftWeight)
 	}

--- a/placement/service/service_test.go
+++ b/placement/service/service_test.go
@@ -576,6 +576,7 @@ func TestFindReplaceInstance(t *testing.T) {
 	assert.Equal(t, 1, len(res))
 	assert.Equal(t, noConflictCandidates[0], res[0])
 
+	// Enable LooseRackCheck, so the rack with less conflicts will be picked.
 	p = NewPlacementService(NewMockStorage(), placement.NewOptions().SetValidZone("z1").SetLooseRackCheck(true)).(*placementService)
 	res, err = p.selector.SelectReplaceInstances(candidates, []string{i4.ID()}, s)
 	assert.NoError(t, err)
@@ -583,6 +584,7 @@ func TestFindReplaceInstance(t *testing.T) {
 	assert.Equal(t, 1, len(res))
 	assert.Equal(t, "r11", res[0].Rack())
 
+	// Disable AllowPartialReplace, so the weight from the candidate instances must be more than the replacing instance.
 	p = NewPlacementService(NewMockStorage(), placement.NewOptions().SetValidZone("z1").SetAllowPartialReplace(false)).(*placementService)
 	_, err = p.selector.SelectReplaceInstances(noConflictCandidates, []string{i3.ID()}, s)
 	assert.Error(t, err)

--- a/placement/service/service_test.go
+++ b/placement/service/service_test.go
@@ -563,25 +563,30 @@ func TestFindReplaceInstance(t *testing.T) {
 	}
 
 	p := NewPlacementService(NewMockStorage(), placement.NewOptions().SetValidZone("z1")).(*placementService)
-	i, err := p.selector.SelectReplaceInstances(candidates, []string{i4.ID()}, s)
+	res, err := p.selector.SelectReplaceInstances(candidates, []string{i4.ID()}, s)
 	assert.Error(t, err)
-	assert.Nil(t, i)
+	assert.Nil(t, res)
 
 	noConflictCandidates := []placement.Instance{
 		placement.NewEmptyInstance("i11", "r0", "z1", "endpoint", 1),
 		placement.NewEmptyInstance("i22", "r0", "z2", "endpoint", 1),
 	}
-	i, err = p.selector.SelectReplaceInstances(noConflictCandidates, []string{i3.ID()}, s)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "could not find enough instance to replace")
-	assert.Nil(t, i)
+	res, err = p.selector.SelectReplaceInstances(noConflictCandidates, []string{i3.ID()}, s)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(res))
+	assert.Equal(t, noConflictCandidates[0], res[0])
 
 	p = NewPlacementService(NewMockStorage(), placement.NewOptions().SetValidZone("z1").SetLooseRackCheck(true)).(*placementService)
-	i, err = p.selector.SelectReplaceInstances(candidates, []string{i4.ID()}, s)
+	res, err = p.selector.SelectReplaceInstances(candidates, []string{i4.ID()}, s)
 	assert.NoError(t, err)
 	// gonna prefer r1 because r1 would only conflict shard 2, r2 would conflict 7,8,9
-	assert.Equal(t, 1, len(i))
-	assert.Equal(t, "r11", i[0].Rack())
+	assert.Equal(t, 1, len(res))
+	assert.Equal(t, "r11", res[0].Rack())
+
+	p = NewPlacementService(NewMockStorage(), placement.NewOptions().SetValidZone("z1").SetAllowPartialReplace(false)).(*placementService)
+	_, err = p.selector.SelectReplaceInstances(noConflictCandidates, []string{i3.ID()}, s)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "could not find enough instance to replace")
 }
 
 func TestMirrorWorkflow(t *testing.T) {


### PR DESCRIPTION
Allow replace with less weight when partial replace is allowed by the options. The algorithm already supports that, in which case the algorithm will fill up the new host and distribute the rest of the load to the rest of the cluster evenly. But right now instance selector is returning errors regardless of the options.

This only affects the non-mirrored mode, while mirrored mode does not allow partial replace and requires the weight to be equal between the new and old instances.

@xichen2020 