### PR TITLE
Allow candidate instance with rack conflicts when partial replace is enabled

### DIFF
--- a/placement/selector/non_mirrored.go
+++ b/placement/selector/non_mirrored.go
@@ -133,7 +133,7 @@ func (f *nonMirroredSelector) SelectReplaceInstances(
 		}
 	}
 
-	groups := groupInstancesByConflict(instances, f.opts.LooseRackCheck())
+	groups := groupInstancesByConflict(instances, f.opts)
 	if len(groups) == 0 {
 		return nil, errNoValidInstance
 	}
@@ -151,7 +151,8 @@ func (f *nonMirroredSelector) SelectReplaceInstances(
 	return result, nil
 }
 
-func groupInstancesByConflict(instancesSortedByConflicts []sortableValue, allowConflict bool) [][]placement.Instance {
+func groupInstancesByConflict(instancesSortedByConflicts []sortableValue, opts placement.Options) [][]placement.Instance {
+	allowConflict := opts.AllowPartialReplace() || opts.LooseRackCheck()
 	sort.Sort(sortableValues(instancesSortedByConflicts))
 	var groups [][]placement.Instance
 	lastSeenConflict := -1

--- a/placement/selector/non_mirrored_test.go
+++ b/placement/selector/non_mirrored_test.go
@@ -42,16 +42,38 @@ func TestGroupInstancesByConflict(t *testing.T) {
 		sortableValue{value: i4, weight: 2},
 	}
 
-	groups := groupInstancesByConflict(instanceConflicts, true)
-	assert.Equal(t, 4, len(groups))
-	assert.Equal(t, i2, groups[0][0])
-	assert.Equal(t, i1, groups[1][0])
-	assert.Equal(t, i4, groups[2][0])
-	assert.Equal(t, i3, groups[3][0])
-
-	groups = groupInstancesByConflict(instanceConflicts, false)
-	assert.Equal(t, 1, len(groups))
-	assert.Equal(t, i2, groups[0][0])
+	testCases := []struct {
+		opts     placement.Options
+		expected [][]placement.Instance
+	}{
+		{
+			opts: placement.NewOptions().SetAllowPartialReplace(true).SetLooseRackCheck(false),
+			expected: [][]placement.Instance{
+				[]placement.Instance{i2},
+				[]placement.Instance{i1},
+				[]placement.Instance{i4},
+				[]placement.Instance{i3},
+			},
+		},
+		{
+			opts: placement.NewOptions().SetAllowPartialReplace(false).SetLooseRackCheck(true),
+			expected: [][]placement.Instance{
+				[]placement.Instance{i2},
+				[]placement.Instance{i1},
+				[]placement.Instance{i4},
+				[]placement.Instance{i3},
+			},
+		},
+		{
+			opts: placement.NewOptions().SetAllowPartialReplace(false).SetLooseRackCheck(false),
+			expected: [][]placement.Instance{
+				[]placement.Instance{i2},
+			},
+		},
+	}
+	for _, test := range testCases {
+		assert.Equal(t, test.expected, groupInstancesByConflict(instanceConflicts, test.opts))
+	}
 }
 
 func TestKnapSack(t *testing.T) {


### PR DESCRIPTION
The algorithm will do the rebalance

@xichen2020 