### PR TITLE
Add an option to control the shard states in the placement

### DIFF
--- a/placement/algo/mirrored.go
+++ b/placement/algo/mirrored.go
@@ -74,17 +74,7 @@ func (a mirroredAlgorithm) InitialPlacement(
 		return nil, err
 	}
 
-	p, err := placementFromMirror(mirrorPlacement, instances, rf)
-	if err != nil {
-		return nil, err
-	}
-
-	// NB(cw): Do not validate shards for initial placement.
-	p, _, err = markAllShardsAvailable(
-		p,
-		a.opts.SetIsShardCutoverFn(nil).SetIsShardCutoffFn(nil),
-	)
-	return p, err
+	return placementFromMirror(mirrorPlacement, instances, rf)
 }
 
 func (a mirroredAlgorithm) AddReplica(p placement.Placement) (placement.Placement, error) {

--- a/placement/algo/mirrored_test.go
+++ b/placement/algo/mirrored_test.go
@@ -1334,7 +1334,7 @@ func TestMirrorAlgoWithSimpleShardStateType(t *testing.T) {
 
 	a := NewAlgorithm(placement.NewOptions().SetIsMirrored(true).
 		SetPlacementCutoverNanosFn(timeNanosGen(1)).
-		SetShardStateType(placement.SimpleShardState))
+		SetShardStateType(placement.IgnoreShardState))
 	p, err := a.InitialPlacement(instances, ids, 2)
 	assert.NoError(t, err)
 	assert.NoError(t, placement.Validate(p))

--- a/placement/algo/mirrored_test.go
+++ b/placement/algo/mirrored_test.go
@@ -1285,3 +1285,126 @@ func TestMarkShardAsAvailableWithMirroredAlgo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, placement.Validate(p))
 }
+
+func TestMirrorAlgoWithSimpleShardStateType(t *testing.T) {
+	i1 := placement.NewInstance().
+		SetID("i1").
+		SetRack("r1").
+		SetEndpoint("endpoint1").
+		SetShardSetID(1).
+		SetWeight(1)
+	i2 := placement.NewInstance().
+		SetID("i2").
+		SetRack("r2").
+		SetEndpoint("endpoint2").
+		SetShardSetID(1).
+		SetWeight(1)
+	i3 := placement.NewInstance().
+		SetID("i3").
+		SetRack("r3").
+		SetEndpoint("endpoint3").
+		SetShardSetID(2).
+		SetWeight(2)
+	i4 := placement.NewInstance().
+		SetID("i4").
+		SetRack("r4").
+		SetEndpoint("endpoint4").
+		SetShardSetID(2).
+		SetWeight(2)
+	i5 := placement.NewInstance().
+		SetID("i5").
+		SetRack("r5").
+		SetEndpoint("endpoint5").
+		SetShardSetID(3).
+		SetWeight(3)
+	i6 := placement.NewInstance().
+		SetID("i6").
+		SetRack("r6").
+		SetEndpoint("endpoint6").
+		SetShardSetID(3).
+		SetWeight(3)
+
+	instances := []placement.Instance{i1, i2, i3, i4, i5, i6}
+
+	numShards := 1024
+	ids := make([]uint32, numShards)
+	for i := 0; i < len(ids); i++ {
+		ids[i] = uint32(i)
+	}
+
+	a := NewAlgorithm(placement.NewOptions().SetIsMirrored(true).
+		SetPlacementCutoverNanosFn(timeNanosGen(1)).
+		SetShardStateType(placement.SimpleShardState))
+	p, err := a.InitialPlacement(instances, ids, 2)
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
+	verifyAllShardsInAvailableState(t, p)
+
+	i7 := placement.NewInstance().
+		SetID("i7").
+		SetRack("r7").
+		SetEndpoint("endpoint7").
+		SetShardSetID(4).
+		SetWeight(4)
+	i8 := placement.NewInstance().
+		SetID("i8").
+		SetRack("r8").
+		SetEndpoint("endpoint8").
+		SetShardSetID(4).
+		SetWeight(4)
+	p, err = a.AddInstances(p, []placement.Instance{i7, i8})
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
+	verifyAllShardsInAvailableState(t, p)
+
+	p, err = a.RemoveInstances(p, []string{i7.ID(), i8.ID()})
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
+	verifyAllShardsInAvailableState(t, p)
+
+	p, err = a.ReplaceInstances(p, []string{"i6"}, []placement.Instance{
+		placement.NewInstance().
+			SetID("i16").
+			SetRack("r6").
+			SetEndpoint("endpoint6").
+			SetShardSetID(3).
+			SetWeight(3),
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
+	verifyAllShardsInAvailableState(t, p)
+
+	i9 := placement.NewInstance().
+		SetID("i9").
+		SetRack("r9").
+		SetEndpoint("endpoint9").
+		SetShardSetID(5).
+		SetWeight(1)
+	i10 := placement.NewInstance().
+		SetID("i10").
+		SetRack("r10").
+		SetEndpoint("endpoint10").
+		SetShardSetID(5).
+		SetWeight(1)
+	p, err = a.AddInstances(p, []placement.Instance{i9, i10})
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
+	verifyAllShardsInAvailableState(t, p)
+
+	p, err = a.ReplaceInstances(p, []string{"i9"}, []placement.Instance{
+		placement.NewInstance().
+			SetID("i19").
+			SetRack("r9").
+			SetEndpoint("endpoint19").
+			SetShardSetID(5).
+			SetWeight(1),
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
+	verifyAllShardsInAvailableState(t, p)
+
+	p, err = a.RemoveInstances(p, []string{"i19", "i10"})
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
+	verifyAllShardsInAvailableState(t, p)
+}

--- a/placement/algo/mirrored_test.go
+++ b/placement/algo/mirrored_test.go
@@ -1334,7 +1334,7 @@ func TestMirrorAlgoWithSimpleShardStateType(t *testing.T) {
 
 	a := NewAlgorithm(placement.NewOptions().SetIsMirrored(true).
 		SetPlacementCutoverNanosFn(timeNanosGen(1)).
-		SetShardStateType(placement.IgnoreShardState))
+		SetShardStateMode(placement.StableShardStateOnly))
 	p, err := a.InitialPlacement(instances, ids, 2)
 	assert.NoError(t, err)
 	assert.NoError(t, placement.Validate(p))

--- a/placement/algo/sharded.go
+++ b/placement/algo/sharded.go
@@ -119,7 +119,6 @@ func (a rackAwarePlacementAlgorithm) RemoveInstances(
 			return nil, err
 		}
 	}
-
 	return tryCleanupShardState(p, a.opts)
 }
 

--- a/placement/algo/sharded.go
+++ b/placement/algo/sharded.go
@@ -58,25 +58,20 @@ func (a rackAwarePlacementAlgorithm) InitialPlacement(
 		return nil, err
 	}
 
-	p := ph.generatePlacement()
+	var (
+		p   = ph.generatePlacement()
+		err error
+	)
 	for i := 1; i < rf; i++ {
-		ph := newAddReplicaHelper(p, a.opts)
-		if err := ph.placeShards(newShards(p.Shards()), nil, ph.Instances()); err != nil {
+		p, err = a.AddReplica(p)
+		if err != nil {
 			return nil, err
 		}
-		if err := ph.optimize(safe); err != nil {
-			return nil, err
-		}
-		p = ph.generatePlacement()
 	}
 
 	// NB(r): All new placements should appear as available for
 	// proper client semantics when calculating consistency results
-	p, _, err := markAllShardsAvailable(
-		p,
-		a.opts.SetIsShardCutoverFn(nil).SetIsShardCutoffFn(nil),
-	)
-	return p, err
+	return cleanupShardState(p, a.opts)
 }
 
 func (a rackAwarePlacementAlgorithm) AddReplica(p placement.Placement) (placement.Placement, error) {
@@ -94,7 +89,7 @@ func (a rackAwarePlacementAlgorithm) AddReplica(p placement.Placement) (placemen
 		return nil, err
 	}
 
-	return ph.generatePlacement(), nil
+	return tryCleanupShardState(ph.generatePlacement(), a.opts)
 }
 
 func (a rackAwarePlacementAlgorithm) RemoveInstances(
@@ -124,7 +119,8 @@ func (a rackAwarePlacementAlgorithm) RemoveInstances(
 			return nil, err
 		}
 	}
-	return p, nil
+
+	return tryCleanupShardState(p, a.opts)
 }
 
 func (a rackAwarePlacementAlgorithm) AddInstances(
@@ -149,7 +145,7 @@ func (a rackAwarePlacementAlgorithm) AddInstances(
 		p = ph.generatePlacement()
 	}
 
-	return p, nil
+	return tryCleanupShardState(p, a.opts)
 }
 
 func (a rackAwarePlacementAlgorithm) ReplaceInstances(
@@ -200,7 +196,7 @@ func (a rackAwarePlacementAlgorithm) ReplaceInstances(
 			return nil, err
 		}
 	}
-	return p, nil
+	return tryCleanupShardState(p, a.opts)
 }
 
 func (a rackAwarePlacementAlgorithm) MarkShardAvailable(

--- a/placement/algo/sharded_helper.go
+++ b/placement/algo/sharded_helper.go
@@ -822,7 +822,7 @@ func tryCleanupShardState(
 	p placement.Placement,
 	opts placement.Options,
 ) (placement.Placement, error) {
-	if opts.ShardStateType() == placement.SimpleShardState {
+	if opts.ShardStateType() == placement.IgnoreShardState {
 		return cleanupShardState(p, opts)
 	}
 	return p, nil

--- a/placement/algo/sharded_helper.go
+++ b/placement/algo/sharded_helper.go
@@ -822,7 +822,7 @@ func tryCleanupShardState(
 	p placement.Placement,
 	opts placement.Options,
 ) (placement.Placement, error) {
-	if opts.ShardStateType() == placement.IgnoreShardState {
+	if opts.ShardStateMode() == placement.StableShardStateOnly {
 		return cleanupShardState(p, opts)
 	}
 	return p, nil

--- a/placement/algo/sharded_helper.go
+++ b/placement/algo/sharded_helper.go
@@ -823,8 +823,7 @@ func tryCleanupShardState(
 	opts placement.Options,
 ) (placement.Placement, error) {
 	if opts.ShardStateType() == placement.SimpleShardState {
-		p, err := cleanupShardState(p, opts)
-		return p, err
+		return cleanupShardState(p, opts)
 	}
 	return p, nil
 }

--- a/placement/algo/sharded_helper.go
+++ b/placement/algo/sharded_helper.go
@@ -818,6 +818,28 @@ func markShardAvailable(p placement.Placement, instanceID string, shardID uint32
 	return p, nil
 }
 
+func tryCleanupShardState(
+	p placement.Placement,
+	opts placement.Options,
+) (placement.Placement, error) {
+	if opts.ShardStateType() == placement.SimpleShardState {
+		p, err := cleanupShardState(p, opts)
+		return p, err
+	}
+	return p, nil
+}
+
+func cleanupShardState(
+	p placement.Placement,
+	opts placement.Options,
+) (placement.Placement, error) {
+	p, _, err := markAllShardsAvailable(
+		p,
+		opts.SetIsShardCutoverFn(nil).SetIsShardCutoffFn(nil),
+	)
+	return p, err
+}
+
 func markAllShardsAvailable(
 	p placement.Placement,
 	opts placement.Options,

--- a/placement/algo/sharded_test.go
+++ b/placement/algo/sharded_test.go
@@ -1192,7 +1192,7 @@ func TestGoodCaseWithSimpleShardStateType(t *testing.T) {
 		SetPlacementCutoverNanosFn(timeNanosGen(1)).
 		SetShardCutoverNanosFn(timeNanosGen(2)).
 		SetShardCutoffNanosFn(timeNanosGen(3)).
-		SetShardStateType(placement.IgnoreShardState)
+		SetShardStateMode(placement.StableShardStateOnly)
 	a := newShardedAlgorithm(opts)
 	p, err := a.InitialPlacement(instances, ids, 1)
 	require.NoError(t, err)

--- a/placement/algo/sharded_test.go
+++ b/placement/algo/sharded_test.go
@@ -1192,7 +1192,7 @@ func TestGoodCaseWithSimpleShardStateType(t *testing.T) {
 		SetPlacementCutoverNanosFn(timeNanosGen(1)).
 		SetShardCutoverNanosFn(timeNanosGen(2)).
 		SetShardCutoffNanosFn(timeNanosGen(3)).
-		SetShardStateType(placement.SimpleShardState)
+		SetShardStateType(placement.IgnoreShardState)
 	a := newShardedAlgorithm(opts)
 	p, err := a.InitialPlacement(instances, ids, 1)
 	require.NoError(t, err)

--- a/placement/algo/sharded_test.go
+++ b/placement/algo/sharded_test.go
@@ -98,7 +98,8 @@ func TestGoodCase(t *testing.T) {
 	p, err = a.AddInstances(p, []placement.Instance{placement.NewEmptyInstance("i21", "r6", "z1", "endpoint", 1)})
 	require.NoError(t, err)
 	validateCutoverCutoffNanos(t, p, opts)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, updated := mustMarkAllShardsAsAvailable(t, p, opts)
+	require.True(t, updated)
 	validateCutoverCutoffNanos(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCase add 1")
 
@@ -110,7 +111,8 @@ func TestGoodCase(t *testing.T) {
 	p, err = a.RemoveInstances(p, []string{i1.ID()})
 	require.NoError(t, err)
 	validateCutoverCutoffNanos(t, p, opts)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, updated = mustMarkAllShardsAsAvailable(t, p, opts)
+	require.True(t, updated)
 	_, exist := p.Instance(i1.ID())
 	assert.False(t, exist)
 	validateCutoverCutoffNanos(t, p, opts)
@@ -127,7 +129,8 @@ func TestGoodCase(t *testing.T) {
 	validateCutoverCutoffNanos(t, p, opts)
 	_, exist = p.Instance(i5.ID())
 	assert.True(t, exist)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, updated = mustMarkAllShardsAsAvailable(t, p, opts)
+	require.True(t, updated)
 	_, exist = p.Instance(i5.ID())
 	assert.False(t, exist)
 	validateCutoverCutoffNanos(t, p, opts)
@@ -141,7 +144,8 @@ func TestGoodCase(t *testing.T) {
 	p, err = a.RemoveInstances(p, []string{i2.ID()})
 	require.NoError(t, err)
 	validateCutoverCutoffNanos(t, p, opts)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, updated = mustMarkAllShardsAsAvailable(t, p, opts)
+	require.True(t, updated)
 	validateCutoverCutoffNanos(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCase remove 1")
 
@@ -153,14 +157,16 @@ func TestGoodCase(t *testing.T) {
 	p, err = a.AddReplica(p)
 	require.NoError(t, err)
 	validateCutoverCutoffNanos(t, p, opts)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, updated = mustMarkAllShardsAsAvailable(t, p, opts)
+	require.True(t, updated)
 	validateCutoverCutoffNanos(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCase replica 2")
 
 	p, err = a.AddReplica(p)
 	require.NoError(t, err)
 	validateCutoverCutoffNanos(t, p, opts)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, updated = mustMarkAllShardsAsAvailable(t, p, opts)
+	require.True(t, updated)
 	validateCutoverCutoffNanos(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCase replica 3")
 
@@ -169,7 +175,8 @@ func TestGoodCase(t *testing.T) {
 	p, err = a.AddInstances(p, []placement.Instance{i10, i11})
 	require.NoError(t, err)
 	validateCutoverCutoffNanos(t, p, opts)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, updated = mustMarkAllShardsAsAvailable(t, p, opts)
+	require.True(t, updated)
 	validateCutoverCutoffNanos(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCase add 2 instances")
 
@@ -177,14 +184,16 @@ func TestGoodCase(t *testing.T) {
 	p, err = a.ReplaceInstances(p, []string{i3.ID()}, []placement.Instance{i13})
 	require.NoError(t, err)
 	validateCutoverCutoffNanos(t, p, opts)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, updated = mustMarkAllShardsAsAvailable(t, p, opts)
+	require.True(t, updated)
 	validateCutoverCutoffNanos(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCase replace 1")
 
 	p, err = a.RemoveInstances(p, []string{i4.ID()})
 	require.NoError(t, err)
 	validateCutoverCutoffNanos(t, p, opts)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, updated = mustMarkAllShardsAsAvailable(t, p, opts)
+	require.True(t, updated)
 	validateCutoverCutoffNanos(t, p, opts)
 	validateDistribution(t, p, 1.02, "TestGoodCase remove 2")
 }
@@ -215,12 +224,12 @@ func TestGoodCaseWithWeight(t *testing.T) {
 
 	p, err = a.AddInstances(p, []placement.Instance{placement.NewEmptyInstance("h21", "r2", "z1", "endpoint", 10)})
 	require.NoError(t, err)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCaseWithWeight add 1")
 
 	p, err = a.RemoveInstances(p, []string{i1.ID()})
 	require.NoError(t, err)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCaseWithWeight remove 1")
 
 	p, err = a.ReplaceInstances(p, []string{i3.ID()},
@@ -229,30 +238,30 @@ func TestGoodCaseWithWeight(t *testing.T) {
 			placement.NewEmptyInstance("h32", "r1", "z1", "endpoint", 10),
 		})
 	require.NoError(t, err)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCaseWithWeight replace 1")
 
 	p, err = a.AddReplica(p)
 	require.NoError(t, err)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCaseWithWeight replica 2")
 
 	p, err = a.AddReplica(p)
 	require.NoError(t, err)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCaseWithWeight replica 3")
 
 	h10 := placement.NewEmptyInstance("h10", "r10", "z1", "endpoint", 10)
 	h11 := placement.NewEmptyInstance("h11", "r7", "z1", "endpoint", 10)
 	p, err = a.AddInstances(p, []placement.Instance{h10, h11})
 	require.NoError(t, err)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCaseWithWeight add 2")
 
 	h13 := placement.NewEmptyInstance("h13", "r5", "z1", "endpoint", 10)
 	p, err = a.ReplaceInstances(p, []string{h11.ID()}, []placement.Instance{h13})
 	require.NoError(t, err)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	validateDistribution(t, p, 1.01, "TestGoodCaseWithWeight replace 1")
 }
 
@@ -572,25 +581,25 @@ func TestLooseRackCheckAlgorithm(t *testing.T) {
 
 	p, err = a.AddReplica(p)
 	require.NoError(t, err)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	require.NoError(t, placement.Validate(p))
 
 	p1, err := a.AddReplica(p)
 	assert.Equal(t, errNotEnoughRacks, err)
 	assert.Nil(t, p1)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	require.NoError(t, placement.Validate(p))
 
 	i4 := placement.NewEmptyInstance("i4", "r2", "z1", "endpoint", 1)
 	p, err = a.AddInstances(p, []placement.Instance{i4})
 	require.NoError(t, err)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	require.NoError(t, placement.Validate(p))
 
 	p1, err = a.AddReplica(p)
 	assert.Equal(t, errNotEnoughRacks, err)
 	assert.Nil(t, p1)
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	require.NoError(t, placement.Validate(p))
 
 	b := newShardedAlgorithm(placement.NewOptions().SetLooseRackCheck(true))
@@ -605,12 +614,12 @@ func TestLooseRackCheckAlgorithm(t *testing.T) {
 	assert.Nil(t, p1)
 	require.NoError(t, placement.Validate(p))
 
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	p, err = b.RemoveInstances(p, []string{i3.ID()})
 	require.NoError(t, err)
 	require.NoError(t, placement.Validate(p))
 
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	i5 := placement.NewEmptyInstance("i5", "r3", "z1", "endpoint", 1)
 	p, err = b.AddInstances(p, []placement.Instance{i5})
 	require.NoError(t, err)
@@ -620,7 +629,7 @@ func TestLooseRackCheckAlgorithm(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, placement.Validate(p))
 
-	p = mustMarkAllShardsAsAvailable(t, p, opts)
+	p, _ = mustMarkAllShardsAsAvailable(t, p, opts)
 	require.NoError(t, placement.Validate(p))
 }
 
@@ -1160,13 +1169,69 @@ func TestMarkShardAsAvailableWithShardedAlgo(t *testing.T) {
 	assert.NoError(t, placement.Validate(p))
 }
 
-func mustMarkAllShardsAsAvailable(t *testing.T, p placement.Placement, opts placement.Options) placement.Placement {
+func TestGoodCaseWithSimpleShardStateType(t *testing.T) {
+	i1 := placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1)
+	i2 := placement.NewEmptyInstance("i2", "r1", "z1", "endpoint", 1)
+	i3 := placement.NewEmptyInstance("i3", "r2", "z1", "endpoint", 1)
+	i4 := placement.NewEmptyInstance("i4", "r2", "z1", "endpoint", 1)
+	i5 := placement.NewEmptyInstance("i5", "r3", "z1", "endpoint", 1)
+	i6 := placement.NewEmptyInstance("i6", "r4", "z1", "endpoint", 1)
+	i7 := placement.NewEmptyInstance("i7", "r5", "z1", "endpoint", 1)
+	i8 := placement.NewEmptyInstance("i8", "r6", "z1", "endpoint", 1)
+	i9 := placement.NewEmptyInstance("i9", "r7", "z1", "endpoint", 1)
+
+	instances := []placement.Instance{i1, i2, i3, i4, i5, i6, i7, i8, i9}
+
+	numShards := 1024
+	ids := make([]uint32, numShards)
+	for i := 0; i < len(ids); i++ {
+		ids[i] = uint32(i)
+	}
+
+	opts := placement.NewOptions().
+		SetPlacementCutoverNanosFn(timeNanosGen(1)).
+		SetShardCutoverNanosFn(timeNanosGen(2)).
+		SetShardCutoffNanosFn(timeNanosGen(3)).
+		SetShardStateType(placement.SimpleShardState)
+	a := newShardedAlgorithm(opts)
+	p, err := a.InitialPlacement(instances, ids, 1)
+	require.NoError(t, err)
+	verifyAllShardsInAvailableState(t, p)
+
+	p, err = a.AddInstances(p, []placement.Instance{placement.NewEmptyInstance("i21", "r6", "z1", "endpoint", 1)})
+	require.NoError(t, err)
+	verifyAllShardsInAvailableState(t, p)
+
+	p, err = a.RemoveInstances(p, []string{i1.ID()})
+	require.NoError(t, err)
+	verifyAllShardsInAvailableState(t, p)
+
+	i12 := placement.NewEmptyInstance("i12", "r3", "z1", "endpoint", 1)
+	p, err = a.ReplaceInstances(p, []string{i5.ID()}, []placement.Instance{i12})
+	require.NoError(t, err)
+	verifyAllShardsInAvailableState(t, p)
+
+	p, err = a.AddReplica(p)
+	require.NoError(t, err)
+	verifyAllShardsInAvailableState(t, p)
+}
+
+func verifyAllShardsInAvailableState(t *testing.T, p placement.Placement) {
+	for _, instance := range p.Instances() {
+		s := instance.Shards()
+		require.Equal(t, len(s.All()), len(s.ShardsForState(shard.Available)))
+		require.Nil(t, s.ShardsForState(shard.Initializing))
+		require.Nil(t, s.ShardsForState(shard.Leaving))
+	}
+}
+
+func mustMarkAllShardsAsAvailable(t *testing.T, p placement.Placement, opts placement.Options) (placement.Placement, bool) {
 	if opts == nil {
 		opts = placement.NewOptions()
 	}
-	p, _, err := markAllShardsAvailable(p, opts)
+	p, updated, err := markAllShardsAvailable(p, opts)
 	require.NoError(t, err)
-	return p
+	return p, updated
 }
 
 func validateCutoverCutoffNanos(t *testing.T, p placement.Placement, opts placement.Options) {

--- a/placement/options.go
+++ b/placement/options.go
@@ -79,7 +79,7 @@ func NewOptions() Options {
 	return options{
 		allowPartialReplace: defaultAllowPartialReplace,
 		isSharded:           defaultIsSharded,
-		shardStateType:      TransitionShardState,
+		shardStateType:      TransitionalShardStates,
 		iopts:               instrument.NewOptions(),
 		placementCutOverFn:  defaultTimeNanosFn,
 		shardCutOverFn:      defaultTimeNanosFn,

--- a/placement/options.go
+++ b/placement/options.go
@@ -59,7 +59,7 @@ func defaultShardValidationFn(s shard.Shard) error { return nil }
 type options struct {
 	looseRackCheck      bool
 	allowPartialReplace bool
-	shardStateType      ShardStateType
+	shardStateMode      ShardStateMode
 	isSharded           bool
 	isMirrored          bool
 	isStaged            bool
@@ -79,7 +79,7 @@ func NewOptions() Options {
 	return options{
 		allowPartialReplace: defaultAllowPartialReplace,
 		isSharded:           defaultIsSharded,
-		shardStateType:      TransitionalShardStates,
+		shardStateMode:      IncludeTransitionalShardStates,
 		iopts:               instrument.NewOptions(),
 		placementCutOverFn:  defaultTimeNanosFn,
 		shardCutOverFn:      defaultTimeNanosFn,
@@ -117,12 +117,12 @@ func (o options) SetIsSharded(sharded bool) Options {
 	return o
 }
 
-func (o options) ShardStateType() ShardStateType {
-	return o.shardStateType
+func (o options) ShardStateMode() ShardStateMode {
+	return o.shardStateMode
 }
 
-func (o options) SetShardStateType(value ShardStateType) Options {
-	o.shardStateType = value
+func (o options) SetShardStateMode(value ShardStateMode) Options {
+	o.shardStateMode = value
 	return o
 }
 

--- a/placement/options.go
+++ b/placement/options.go
@@ -59,6 +59,7 @@ func defaultShardValidationFn(s shard.Shard) error { return nil }
 type options struct {
 	looseRackCheck      bool
 	allowPartialReplace bool
+	shardStateType      ShardStateType
 	isSharded           bool
 	isMirrored          bool
 	isStaged            bool
@@ -78,6 +79,7 @@ func NewOptions() Options {
 	return options{
 		allowPartialReplace: defaultAllowPartialReplace,
 		isSharded:           defaultIsSharded,
+		shardStateType:      TransitionShardState,
 		iopts:               instrument.NewOptions(),
 		placementCutOverFn:  defaultTimeNanosFn,
 		shardCutOverFn:      defaultTimeNanosFn,
@@ -112,6 +114,15 @@ func (o options) IsSharded() bool {
 
 func (o options) SetIsSharded(sharded bool) Options {
 	o.isSharded = sharded
+	return o
+}
+
+func (o options) ShardStateType() ShardStateType {
+	return o.shardStateType
+}
+
+func (o options) SetShardStateType(value ShardStateType) Options {
+	o.shardStateType = value
 	return o
 }
 

--- a/placement/options_test.go
+++ b/placement/options_test.go
@@ -42,7 +42,7 @@ func TestPlacementOptions(t *testing.T) {
 	assert.False(t, o.LooseRackCheck())
 	assert.True(t, o.AllowPartialReplace())
 	assert.True(t, o.IsSharded())
-	assert.Equal(t, TransitionalShardStates, o.ShardStateType())
+	assert.Equal(t, IncludeTransitionalShardStates, o.ShardStateMode())
 	assert.False(t, o.Dryrun())
 	assert.False(t, o.IsMirrored())
 	assert.False(t, o.IsStaged())
@@ -60,8 +60,8 @@ func TestPlacementOptions(t *testing.T) {
 	o = o.SetIsSharded(false)
 	assert.False(t, o.IsSharded())
 
-	o = o.SetShardStateType(IgnoreShardState)
-	assert.Equal(t, IgnoreShardState, o.ShardStateType())
+	o = o.SetShardStateMode(StableShardStateOnly)
+	assert.Equal(t, StableShardStateOnly, o.ShardStateMode())
 
 	o = o.SetDryrun(true)
 	assert.True(t, o.Dryrun())

--- a/placement/options_test.go
+++ b/placement/options_test.go
@@ -42,6 +42,7 @@ func TestPlacementOptions(t *testing.T) {
 	assert.False(t, o.LooseRackCheck())
 	assert.True(t, o.AllowPartialReplace())
 	assert.True(t, o.IsSharded())
+	assert.Equal(t, TransitionShardState, o.ShardStateType())
 	assert.False(t, o.Dryrun())
 	assert.False(t, o.IsMirrored())
 	assert.False(t, o.IsStaged())
@@ -58,6 +59,9 @@ func TestPlacementOptions(t *testing.T) {
 
 	o = o.SetIsSharded(false)
 	assert.False(t, o.IsSharded())
+
+	o = o.SetShardStateType(SimpleShardState)
+	assert.Equal(t, SimpleShardState, o.ShardStateType())
 
 	o = o.SetDryrun(true)
 	assert.True(t, o.Dryrun())

--- a/placement/options_test.go
+++ b/placement/options_test.go
@@ -42,7 +42,7 @@ func TestPlacementOptions(t *testing.T) {
 	assert.False(t, o.LooseRackCheck())
 	assert.True(t, o.AllowPartialReplace())
 	assert.True(t, o.IsSharded())
-	assert.Equal(t, TransitionShardState, o.ShardStateType())
+	assert.Equal(t, TransitionalShardStates, o.ShardStateType())
 	assert.False(t, o.Dryrun())
 	assert.False(t, o.IsMirrored())
 	assert.False(t, o.IsStaged())
@@ -60,8 +60,8 @@ func TestPlacementOptions(t *testing.T) {
 	o = o.SetIsSharded(false)
 	assert.False(t, o.IsSharded())
 
-	o = o.SetShardStateType(SimpleShardState)
-	assert.Equal(t, SimpleShardState, o.ShardStateType())
+	o = o.SetShardStateType(IgnoreShardState)
+	assert.Equal(t, IgnoreShardState, o.ShardStateType())
 
 	o = o.SetDryrun(true)
 	assert.True(t, o.Dryrun())

--- a/placement/types.go
+++ b/placement/types.go
@@ -331,11 +331,11 @@ type Options interface {
 	// SetIsSharded sets IsSharded.
 	SetIsSharded(sharded bool) Options
 
-	// ShardStateType describes the way to manage shard state in the placement.
-	ShardStateType() ShardStateType
+	// ShardStateMode describes the mode to manage shard state in the placement.
+	ShardStateMode() ShardStateMode
 
-	// SetShardStateType sets ShardStateType.
-	SetShardStateType(value ShardStateType) Options
+	// SetShardStateMode sets ShardStateMode.
+	SetShardStateMode(value ShardStateMode) Options
 
 	// Dryrun will try to perform the placement operation but will not persist the final result.
 	Dryrun() bool
@@ -410,15 +410,15 @@ type Options interface {
 	SetNowFn(fn clock.NowFn) Options
 }
 
-// ShardStateType describes the way to manage shard state in the placement.
-type ShardStateType int
+// ShardStateMode describes the way to manage shard state in the placement.
+type ShardStateMode int
 
 const (
-	// IgnoreShardState means the shard state in the placement should be ignored.
-	IgnoreShardState ShardStateType = iota
+	// StableShardStateOnly means the placement should only keep stable shard state.
+	StableShardStateOnly ShardStateMode = iota
 
-	// TransitionalShardStates means the transitional shard states will be included in the placement.
-	TransitionalShardStates
+	// IncludeTransitionalShardStates means the placement will include transitional shard states.
+	IncludeTransitionalShardStates
 )
 
 // Storage provides read and write access to placement.

--- a/placement/types.go
+++ b/placement/types.go
@@ -331,6 +331,12 @@ type Options interface {
 	// SetIsSharded sets IsSharded.
 	SetIsSharded(sharded bool) Options
 
+	// ShardStateType describes the way to manage shard state in the placement.
+	ShardStateType() ShardStateType
+
+	// SetShardStateType sets ShardStateType.
+	SetShardStateType(value ShardStateType) Options
+
 	// Dryrun will try to perform the placement operation but will not persist the final result.
 	Dryrun() bool
 
@@ -403,6 +409,18 @@ type Options interface {
 	// SetNowFn sets the function to get time now.
 	SetNowFn(fn clock.NowFn) Options
 }
+
+// ShardStateType describes the way to manage shard state in the placement.
+type ShardStateType int
+
+const (
+	// SimpleShardState means all shards in the placement will be in Available state.
+	SimpleShardState ShardStateType = iota
+
+	// TransitionShardState means the shard states around transition (Initializing or Leaving)
+	// will also be included in the placement.
+	TransitionShardState
+)
 
 // Storage provides read and write access to placement.
 type Storage interface {

--- a/placement/types.go
+++ b/placement/types.go
@@ -414,12 +414,11 @@ type Options interface {
 type ShardStateType int
 
 const (
-	// SimpleShardState means all shards in the placement will be in Available state.
-	SimpleShardState ShardStateType = iota
+	// IgnoreShardState means the shard state in the placement should be ignored.
+	IgnoreShardState ShardStateType = iota
 
-	// TransitionShardState means the shard states around transition (Initializing or Leaving)
-	// will also be included in the placement.
-	TransitionShardState
+	// TransitionalShardStates means the transitional shard states will be included in the placement.
+	TransitionalShardStates
 )
 
 // Storage provides read and write access to placement.


### PR DESCRIPTION
1, Added ShardStateType in placement/types.go: 
- By default we will use TransitionShardState, which includes Initializing, Available, Leaving states, for M3DB and M3Agg
- SimpleShardState will only have shards in Available state, can be used by the cache or indexer

2, Algo will pick up the new option in tryCleanupShardState()

@xichen2020 @robskillington 