### PR TITLE
Fix flaky test in heartbeat store

### DIFF
--- a/services/heartbeat/etcd/store.go
+++ b/services/heartbeat/etcd/store.go
@@ -192,9 +192,12 @@ func (c *client) get(key string) ([]string, error) {
 	ctx, cancel := c.context()
 	defer cancel()
 
-	resp, err := c.kv.Get(ctx, key,
+	resp, err := c.kv.Get(
+		ctx,
+		key,
 		clientv3.WithPrefix(),
-		clientv3.WithKeysOnly())
+		clientv3.WithKeysOnly(),
+	)
 
 	if err != nil {
 		c.m.etcdGetError.Inc(1)


### PR DESCRIPTION
kv watch by default will do a get() upon creation, which will call heartbeatStore.Get(), for a service with no heartbeats it will return an empty string, so all watch should expect a notification soon after creation regardless whether there is any heartbeat for the service.

@schallert 