### PR TITLE
[selector] Add option to add all candidates in non-mirrored selector

### DIFF
--- a/placement/options.go
+++ b/placement/options.go
@@ -58,6 +58,7 @@ func defaultShardValidationFn(s shard.Shard) error { return nil }
 
 type options struct {
 	allowPartialReplace bool
+	addAllCandidates    bool
 	shardStateMode      ShardStateMode
 	isSharded           bool
 	isMirrored          bool
@@ -95,6 +96,15 @@ func (o options) AllowPartialReplace() bool {
 
 func (o options) SetAllowPartialReplace(allowPartialReplace bool) Options {
 	o.allowPartialReplace = allowPartialReplace
+	return o
+}
+
+func (o options) AddAllCandidates() bool {
+	return o.addAllCandidates
+}
+
+func (o options) SetAddAllCandidates(addAllCandidates bool) Options {
+	o.addAllCandidates = addAllCandidates
 	return o
 }
 

--- a/placement/options_test.go
+++ b/placement/options_test.go
@@ -40,6 +40,7 @@ func TestDeploymentOptions(t *testing.T) {
 func TestPlacementOptions(t *testing.T) {
 	o := NewOptions()
 	assert.True(t, o.AllowPartialReplace())
+	assert.False(t, o.AddAllCandidates())
 	assert.True(t, o.IsSharded())
 	assert.Equal(t, IncludeTransitionalShardStates, o.ShardStateMode())
 	assert.False(t, o.Dryrun())
@@ -52,6 +53,9 @@ func TestPlacementOptions(t *testing.T) {
 
 	o = o.SetAllowPartialReplace(false)
 	assert.False(t, o.AllowPartialReplace())
+
+	o = o.SetAddAllCandidates(true)
+	assert.True(t, o.AddAllCandidates())
 
 	o = o.SetIsSharded(false)
 	assert.False(t, o.IsSharded())

--- a/placement/placement_mock.go
+++ b/placement/placement_mock.go
@@ -1177,6 +1177,30 @@ func (_mr *MockOptionsMockRecorder) SetAllowPartialReplace(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "SetAllowPartialReplace", reflect.TypeOf((*MockOptions)(nil).SetAllowPartialReplace), arg0)
 }
 
+// AddAllCandidates mocks base method
+func (_m *MockOptions) AddAllCandidates() bool {
+	ret := _m.ctrl.Call(_m, "AddAllCandidates")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AddAllCandidates indicates an expected call of AddAllCandidates
+func (_mr *MockOptionsMockRecorder) AddAllCandidates() *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "AddAllCandidates", reflect.TypeOf((*MockOptions)(nil).AddAllCandidates))
+}
+
+// SetAddAllCandidates mocks base method
+func (_m *MockOptions) SetAddAllCandidates(addAllCandidates bool) Options {
+	ret := _m.ctrl.Call(_m, "SetAddAllCandidates", addAllCandidates)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+// SetAddAllCandidates indicates an expected call of SetAddAllCandidates
+func (_mr *MockOptionsMockRecorder) SetAddAllCandidates(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "SetAddAllCandidates", reflect.TypeOf((*MockOptions)(nil).SetAddAllCandidates), arg0)
+}
+
 // IsSharded mocks base method
 func (_m *MockOptions) IsSharded() bool {
 	ret := _m.ctrl.Call(_m, "IsSharded")

--- a/placement/selector/non_mirrored.go
+++ b/placement/selector/non_mirrored.go
@@ -58,39 +58,15 @@ func (f *nonMirroredSelector) SelectAddingInstances(
 		return nil, err
 	}
 
-	candidateGroups := buildIsolationGroupMap(candidates)
-
-	existingGroups := buildIsolationGroupMap(p.Instances())
-
-	// If there is a isolation group not in the current placement, prefer the isolation group.
-	for r, instances := range candidateGroups {
-		if _, exist := existingGroups[r]; !exist {
-			// All the isolation groups have at least 1 instance.
-			return instances[:1], nil
-		}
+	if f.opts.AddAllCandidates() {
+		return candidates, nil
 	}
 
-	// Otherwise sort the isolation groups in the current placement
-	// by capacity and find a instance from least sized isolation group.
-	groups := make(sortableValues, 0, len(existingGroups))
-	for group, instances := range existingGroups {
-		weight := 0
-		for _, i := range instances {
-			weight += int(i.Weight())
-		}
-		groups = append(groups, sortableValue{value: group, weight: weight})
+	instance, err := selectSingleCandidate(candidates, p)
+	if err != nil {
+		return nil, err
 	}
-	sort.Sort(groups)
-
-	for _, group := range groups {
-		if i, exist := candidateGroups[group.value.(string)]; exist {
-			for _, instance := range i {
-				return []placement.Instance{instance}, nil
-			}
-		}
-	}
-	// no instance in the candidate instances can be added to the placement
-	return nil, errNoValidInstance
+	return []placement.Instance{instance}, nil
 }
 
 func (f *nonMirroredSelector) SelectReplaceInstances(
@@ -240,6 +216,45 @@ func buildIsolationGroupMap(candidates []placement.Instance) map[string][]placem
 		result[instance.IsolationGroup()] = append(result[instance.IsolationGroup()], instance)
 	}
 	return result
+}
+
+func selectSingleCandidate(
+	candidates []placement.Instance,
+	p placement.Placement,
+) (placement.Instance, error) {
+	candidateGroups := buildIsolationGroupMap(candidates)
+	existingGroups := buildIsolationGroupMap(p.Instances())
+
+	// If there is a isolation group not in the current placement, prefer the isolation group.
+	for r, instances := range candidateGroups {
+		if _, exist := existingGroups[r]; !exist {
+			// All the isolation groups have at least 1 instance.
+			return instances[0], nil
+		}
+	}
+
+	// Otherwise sort the isolation groups in the current placement
+	// by capacity and find a instance from least sized isolation group.
+	groups := make(sortableValues, 0, len(existingGroups))
+	for group, instances := range existingGroups {
+		weight := 0
+		for _, i := range instances {
+			weight += int(i.Weight())
+		}
+		groups = append(groups, sortableValue{value: group, weight: weight})
+	}
+	sort.Sort(groups)
+
+	for _, group := range groups {
+		if i, exist := candidateGroups[group.value.(string)]; exist {
+			for _, instance := range i {
+				return instance, nil
+			}
+		}
+	}
+
+	// no instance in the candidate instances can be added to the placement
+	return nil, errNoValidInstance
 }
 
 type sortableValue struct {

--- a/placement/selector/non_mirrored.go
+++ b/placement/selector/non_mirrored.go
@@ -225,7 +225,7 @@ func selectSingleCandidate(
 	candidateGroups := buildIsolationGroupMap(candidates)
 	existingGroups := buildIsolationGroupMap(p.Instances())
 
-	// If there is a isolation group not in the current placement, prefer the isolation group.
+	// If there is an isolation group not in the current placement, prefer the isolation group.
 	for r, instances := range candidateGroups {
 		if _, exist := existingGroups[r]; !exist {
 			// All the isolation groups have at least 1 instance.

--- a/placement/selector/non_mirrored_test.go
+++ b/placement/selector/non_mirrored_test.go
@@ -296,7 +296,7 @@ func TestSelectAddingInstanceForNonMirrored(t *testing.T) {
 	tests := []struct {
 		name                  string
 		placement             placement.Placement
-		selector              placement.InstanceSelector
+		opts                  placement.Options
 		candidates            []placement.Instance
 		expectedNumAdded      int
 		expectedInstanceAdded placement.Instance
@@ -304,7 +304,7 @@ func TestSelectAddingInstanceForNonMirrored(t *testing.T) {
 		{
 			name:                  "New Isolation Group",
 			placement:             placement.NewPlacement().SetInstances([]placement.Instance{i1}),
-			selector:              newNonMirroredSelector(placement.NewOptions().SetAddAllCandidates(false)),
+			opts:                  placement.NewOptions().SetAddAllCandidates(false),
 			candidates:            []placement.Instance{i2, i3},
 			expectedNumAdded:      1,
 			expectedInstanceAdded: i2,
@@ -312,7 +312,7 @@ func TestSelectAddingInstanceForNonMirrored(t *testing.T) {
 		{
 			name:                  "Least Weighted Isolation Group",
 			placement:             placement.NewPlacement().SetInstances([]placement.Instance{i1, i4}),
-			selector:              newNonMirroredSelector(placement.NewOptions().SetAddAllCandidates(false)),
+			opts:                  placement.NewOptions().SetAddAllCandidates(false),
 			candidates:            []placement.Instance{i2, i3},
 			expectedNumAdded:      1,
 			expectedInstanceAdded: i2,
@@ -320,7 +320,7 @@ func TestSelectAddingInstanceForNonMirrored(t *testing.T) {
 		{
 			name:             "Add All Candidates",
 			placement:        placement.NewPlacement().SetInstances([]placement.Instance{i1}),
-			selector:         newNonMirroredSelector(placement.NewOptions().SetAddAllCandidates(true)),
+			opts:             placement.NewOptions().SetAddAllCandidates(true),
 			candidates:       []placement.Instance{i2, i3, i4},
 			expectedNumAdded: 3,
 		},
@@ -328,7 +328,8 @@ func TestSelectAddingInstanceForNonMirrored(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			added, err := test.selector.SelectAddingInstances(test.candidates, test.placement)
+			selector := newNonMirroredSelector(test.opts)
+			added, err := selector.SelectAddingInstances(test.candidates, test.placement)
 			require.NoError(t, err)
 			require.Equal(t, test.expectedNumAdded, len(added))
 			if test.expectedInstanceAdded != nil {

--- a/placement/selector/non_mirrored_test.go
+++ b/placement/selector/non_mirrored_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3cluster/placement"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGroupInstancesByConflict(t *testing.T) {
@@ -271,5 +272,68 @@ func TestFilterZones(t *testing.T) {
 	for args, exp := range tests {
 		res := filterZones(args.p, args.candidates, args.opts)
 		assert.Equal(t, exp, res)
+	}
+}
+
+func TestSelectAddingInstanceForNonMirrored(t *testing.T) {
+	i1 := placement.NewInstance().
+		SetID("i1").
+		SetIsolationGroup("r1").
+		SetWeight(3)
+	i2 := placement.NewInstance().
+		SetID("i2").
+		SetIsolationGroup("r2").
+		SetWeight(1)
+	i3 := placement.NewInstance().
+		SetID("i3").
+		SetIsolationGroup("r1").
+		SetWeight(1)
+	i4 := placement.NewInstance().
+		SetID("i4").
+		SetIsolationGroup("r2").
+		SetWeight(2)
+
+	tests := []struct {
+		name                  string
+		placement             placement.Placement
+		selector              placement.InstanceSelector
+		candidates            []placement.Instance
+		expectedNumAdded      int
+		expectedInstanceAdded placement.Instance
+	}{
+		{
+			name:                  "New Isolation Group",
+			placement:             placement.NewPlacement().SetInstances([]placement.Instance{i1}),
+			selector:              newNonMirroredSelector(placement.NewOptions().SetAddAllCandidates(false)),
+			candidates:            []placement.Instance{i2, i3},
+			expectedNumAdded:      1,
+			expectedInstanceAdded: i2,
+		},
+		{
+			name:                  "Least Weighted Isolation Group",
+			placement:             placement.NewPlacement().SetInstances([]placement.Instance{i1, i4}),
+			selector:              newNonMirroredSelector(placement.NewOptions().SetAddAllCandidates(false)),
+			candidates:            []placement.Instance{i2, i3},
+			expectedNumAdded:      1,
+			expectedInstanceAdded: i2,
+		},
+		{
+			name:             "Add All Candidates",
+			placement:        placement.NewPlacement().SetInstances([]placement.Instance{i1}),
+			selector:         newNonMirroredSelector(placement.NewOptions().SetAddAllCandidates(true)),
+			candidates:       []placement.Instance{i2, i3, i4},
+			expectedNumAdded: 3,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			added, err := test.selector.SelectAddingInstances(test.candidates, test.placement)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedNumAdded, len(added))
+			if test.expectedInstanceAdded != nil {
+				require.Equal(t, test.expectedInstanceAdded, added[0])
+			}
+		})
 	}
 }

--- a/placement/types.go
+++ b/placement/types.go
@@ -318,6 +318,13 @@ type Options interface {
 	// SetAllowPartialReplace sets AllowPartialReplace.
 	SetAllowPartialReplace(allowPartialReplace bool) Options
 
+	// AddAllCandidates determines whether the placement will attempt to add all
+	// candidates when adding instances or just a single one.
+	AddAllCandidates() bool
+
+	// SetAddAllCandidates sets AddAllCandidates.
+	SetAddAllCandidates(addAllCandidates bool) Options
+
 	// IsSharded describes whether a placement needs to be sharded,
 	// when set to false, no specific shards will be assigned to any instance.
 	IsSharded() bool


### PR DESCRIPTION
This diff adds an option to allow the non-mirrored selector to add all candidates at once. This will be beneficial in caching tiers where each host may run more than one instance of the caching process.