### PR TITLE
[service] Update replace selector to support adding all instances

### DIFF
--- a/placement/selector/non_mirrored.go
+++ b/placement/selector/non_mirrored.go
@@ -89,7 +89,7 @@ func (f *nonMirroredSelector) SelectReplaceInstances(
 	}
 
 	if f.opts.AddAllCandidates() {
-		if err := f.validateReplaceInstances(candidates, leavingInstances, p); err != nil {
+		if err := f.validateReplaceInstances(candidates, leavingInstances); err != nil {
 			return nil, err
 		}
 		return candidates, nil
@@ -144,7 +144,6 @@ func (f *nonMirroredSelector) selectReplaceInstances(
 
 func (f *nonMirroredSelector) validateReplaceInstances(
 	candidates, leavingInstances []placement.Instance,
-	p placement.Placement,
 ) error {
 	var leavingWeight int
 	for _, instance := range leavingInstances {

--- a/placement/selector/non_mirrored.go
+++ b/placement/selector/non_mirrored.go
@@ -154,7 +154,7 @@ func (f *nonMirroredSelector) validateReplaceInstances(
 		candidateWeight += int(instance.Weight())
 	}
 
-	if leavingWeight-candidateWeight > 0 && !f.opts.AllowPartialReplace() {
+	if leavingWeight > candidateWeight && !f.opts.AllowPartialReplace() {
 		return fmt.Errorf("could not find enough instances to replace %v, %d weight could not be replaced",
 			leavingInstances, leavingWeight)
 	}

--- a/placement/selector/non_mirrored.go
+++ b/placement/selector/non_mirrored.go
@@ -88,10 +88,26 @@ func (f *nonMirroredSelector) SelectReplaceInstances(
 		leavingInstances = append(leavingInstances, leavingInstance)
 	}
 
+	if f.opts.AddAllCandidates() {
+		if err := f.validateReplaceInstances(candidates, leavingInstances, p); err != nil {
+			return nil, err
+		}
+		return candidates, nil
+	}
+
+	return f.selectReplaceInstances(candidates, leavingInstances, p)
+}
+
+// selectReplaceInstances returns a sufficient number of instances to replace the weight
+// of the leaving instances.
+func (f *nonMirroredSelector) selectReplaceInstances(
+	candidates, leavingInstances []placement.Instance,
+	p placement.Placement,
+) ([]placement.Instance, error) {
 	// Map isolation group to instances.
 	candidateGroups := buildIsolationGroupMap(candidates)
 
-	// Otherwise sort the candidate instances by the number of conflicts.
+	// Sort the candidate instances by the number of conflicts.
 	ph := algo.NewPlacementHelper(p, f.opts)
 	instances := make([]sortableValue, 0, len(candidateGroups))
 	for group, instancesInGroup := range candidateGroups {
@@ -120,10 +136,30 @@ func (f *nonMirroredSelector) SelectReplaceInstances(
 	result, leftWeight := fillWeight(groups, int(totalWeight))
 
 	if leftWeight > 0 && !f.opts.AllowPartialReplace() {
-		return nil, fmt.Errorf("could not find enough instance to replace %v, %d weight could not be replaced",
+		return nil, fmt.Errorf("could not find enough instances to replace %v, %d weight could not be replaced",
 			leavingInstances, leftWeight)
 	}
 	return result, nil
+}
+
+func (f *nonMirroredSelector) validateReplaceInstances(
+	candidates, leavingInstances []placement.Instance,
+	p placement.Placement,
+) error {
+	var leavingWeight int
+	for _, instance := range leavingInstances {
+		leavingWeight += int(instance.Weight())
+	}
+	var candidateWeight int
+	for _, instance := range candidates {
+		candidateWeight += int(instance.Weight())
+	}
+
+	if leavingWeight-candidateWeight > 0 && !f.opts.AllowPartialReplace() {
+		return fmt.Errorf("could not find enough instances to replace %v, %d weight could not be replaced",
+			leavingInstances, leavingWeight)
+	}
+	return nil
 }
 
 func groupInstancesByConflict(instancesSortedByConflicts []sortableValue, opts placement.Options) [][]placement.Instance {

--- a/placement/selector/non_mirrored_test.go
+++ b/placement/selector/non_mirrored_test.go
@@ -294,35 +294,32 @@ func TestSelectAddingInstanceForNonMirrored(t *testing.T) {
 		SetWeight(2)
 
 	tests := []struct {
-		name                  string
-		placement             placement.Placement
-		opts                  placement.Options
-		candidates            []placement.Instance
-		expectedNumAdded      int
-		expectedInstanceAdded placement.Instance
+		name        string
+		placement   placement.Placement
+		opts        placement.Options
+		candidates  []placement.Instance
+		expectAdded []placement.Instance
 	}{
 		{
-			name:                  "New Isolation Group",
-			placement:             placement.NewPlacement().SetInstances([]placement.Instance{i1}),
-			opts:                  placement.NewOptions().SetAddAllCandidates(false),
-			candidates:            []placement.Instance{i2, i3},
-			expectedNumAdded:      1,
-			expectedInstanceAdded: i2,
+			name:        "New Isolation Group",
+			placement:   placement.NewPlacement().SetInstances([]placement.Instance{i1}),
+			opts:        placement.NewOptions().SetAddAllCandidates(false),
+			candidates:  []placement.Instance{i2, i3},
+			expectAdded: []placement.Instance{i2},
 		},
 		{
-			name:                  "Least Weighted Isolation Group",
-			placement:             placement.NewPlacement().SetInstances([]placement.Instance{i1, i4}),
-			opts:                  placement.NewOptions().SetAddAllCandidates(false),
-			candidates:            []placement.Instance{i2, i3},
-			expectedNumAdded:      1,
-			expectedInstanceAdded: i2,
+			name:        "Least Weighted Isolation Group",
+			placement:   placement.NewPlacement().SetInstances([]placement.Instance{i1, i4}),
+			opts:        placement.NewOptions().SetAddAllCandidates(false),
+			candidates:  []placement.Instance{i2, i3},
+			expectAdded: []placement.Instance{i2},
 		},
 		{
-			name:             "Add All Candidates",
-			placement:        placement.NewPlacement().SetInstances([]placement.Instance{i1}),
-			opts:             placement.NewOptions().SetAddAllCandidates(true),
-			candidates:       []placement.Instance{i2, i3, i4},
-			expectedNumAdded: 3,
+			name:        "Add All Candidates",
+			placement:   placement.NewPlacement().SetInstances([]placement.Instance{i1}),
+			opts:        placement.NewOptions().SetAddAllCandidates(true),
+			candidates:  []placement.Instance{i2, i3, i4},
+			expectAdded: []placement.Instance{i2, i3, i4},
 		},
 	}
 
@@ -331,10 +328,7 @@ func TestSelectAddingInstanceForNonMirrored(t *testing.T) {
 			selector := newNonMirroredSelector(test.opts)
 			added, err := selector.SelectAddingInstances(test.candidates, test.placement)
 			require.NoError(t, err)
-			require.Equal(t, test.expectedNumAdded, len(added))
-			if test.expectedInstanceAdded != nil {
-				require.Equal(t, test.expectedInstanceAdded, added[0])
-			}
+			require.Equal(t, test.expectAdded, added)
 		})
 	}
 }
@@ -358,43 +352,43 @@ func TestSelectReplaceInstanceForNonMirrored(t *testing.T) {
 		SetWeight(2)
 
 	tests := []struct {
-		name          string
-		placement     placement.Placement
-		opts          placement.Options
-		candidates    []placement.Instance
-		leavingIDs    []string
-		expectErr     bool
-		expectedAdded []placement.Instance
+		name        string
+		placement   placement.Placement
+		opts        placement.Options
+		candidates  []placement.Instance
+		leavingIDs  []string
+		expectErr   bool
+		expectAdded []placement.Instance
 	}{
 		{
-			name:          "Replace With Same Weight",
-			placement:     placement.NewPlacement().SetInstances([]placement.Instance{i1, i2}),
-			opts:          placement.NewOptions().SetAddAllCandidates(false).SetAllowPartialReplace(false),
-			candidates:    []placement.Instance{i3, i4},
-			leavingIDs:    []string{"i2"},
-			expectErr:     false,
-			expectedAdded: []placement.Instance{i3},
+			name:        "Replace With Instance of Same Weight",
+			placement:   placement.NewPlacement().SetInstances([]placement.Instance{i1, i2}),
+			opts:        placement.NewOptions().SetAddAllCandidates(false).SetAllowPartialReplace(false),
+			candidates:  []placement.Instance{i3, i4},
+			leavingIDs:  []string{"i2"},
+			expectErr:   false,
+			expectAdded: []placement.Instance{i3},
 		},
 		{
-			name:          "Add All Candidates",
-			placement:     placement.NewPlacement().SetInstances([]placement.Instance{i1, i2}),
-			opts:          placement.NewOptions().SetAddAllCandidates(true).SetAllowPartialReplace(false),
-			candidates:    []placement.Instance{i3, i4},
-			leavingIDs:    []string{"i2"},
-			expectErr:     false,
-			expectedAdded: []placement.Instance{i3, i4},
+			name:        "Add All Candidates",
+			placement:   placement.NewPlacement().SetInstances([]placement.Instance{i1, i2}),
+			opts:        placement.NewOptions().SetAddAllCandidates(true).SetAllowPartialReplace(false),
+			candidates:  []placement.Instance{i3, i4},
+			leavingIDs:  []string{"i2"},
+			expectErr:   false,
+			expectAdded: []placement.Instance{i3, i4},
 		},
 		{
-			name:          "Not Enough Weight With No Partial Replace",
-			placement:     placement.NewPlacement().SetInstances([]placement.Instance{i1, i2}),
-			opts:          placement.NewOptions().SetAddAllCandidates(false).SetAllowPartialReplace(true),
-			candidates:    []placement.Instance{i3, i4},
-			leavingIDs:    []string{"i1"},
-			expectErr:     false,
-			expectedAdded: []placement.Instance{i3, i4},
+			name:        "Not Enough Weight With Partial Replace",
+			placement:   placement.NewPlacement().SetInstances([]placement.Instance{i1, i2}),
+			opts:        placement.NewOptions().SetAddAllCandidates(false).SetAllowPartialReplace(true),
+			candidates:  []placement.Instance{i3, i4},
+			leavingIDs:  []string{"i1"},
+			expectErr:   false,
+			expectAdded: []placement.Instance{i3, i4},
 		},
 		{
-			name:       "Not Enough Weight Without No Partial Replace",
+			name:       "Not Enough Weight Without Partial Replace",
 			placement:  placement.NewPlacement().SetInstances([]placement.Instance{i1, i2}),
 			opts:       placement.NewOptions().SetAddAllCandidates(false).SetAllowPartialReplace(false),
 			candidates: []placement.Instance{i3, i4},
@@ -412,7 +406,7 @@ func TestSelectReplaceInstanceForNonMirrored(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, test.expectedAdded, added)
+			require.Equal(t, test.expectAdded, added)
 		})
 	}
 }


### PR DESCRIPTION
Propagate the option to add all candidates in calls to replace all instances.