### PR TITLE
[kv] Support watch start revision in watch store

### DIFF
--- a/etcd/watchmanager/manager.go
+++ b/etcd/watchmanager/manager.go
@@ -152,7 +152,6 @@ func (w *manager) Watch(key string) {
 					w.logger.Warnf("recreating watch at revision %d", r.CompactRevision)
 					startRev = r.CompactRevision
 					watchChan = nil
-					continue
 				}
 			}
 

--- a/etcd/watchmanager/manager.go
+++ b/etcd/watchmanager/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3x/log"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	"github.com/uber-go/tally"
 )
 
@@ -66,17 +67,21 @@ type metrics struct {
 	etcdWatchReset  tally.Counter
 }
 
-func (w *manager) watchChanWithTimeout(key string) (clientv3.WatchChan, context.CancelFunc, error) {
+func (w *manager) watchChanWithTimeout(key string, rev int64) (clientv3.WatchChan, context.CancelFunc, error) {
 	doneCh := make(chan struct{})
 
 	ctx, cancelFn := context.WithCancel(clientv3.WithRequireLeader(context.Background()))
 
 	var watchChan clientv3.WatchChan
 	go func() {
+		wOpts := w.opts.WatchOptions()
+		if rev > 0 {
+			wOpts = append(wOpts, clientv3.WithRev(rev))
+		}
 		watchChan = w.opts.Watcher().Watch(
 			ctx,
 			key,
-			w.opts.WatchOptions()...,
+			wOpts...,
 		)
 		close(doneCh)
 	}()
@@ -95,6 +100,7 @@ func (w *manager) Watch(key string) {
 	ticker := time.Tick(w.opts.WatchChanCheckInterval()) //nolint: megacheck
 
 	var (
+		startRev  int64
 		watchChan clientv3.WatchChan
 		cancelFn  context.CancelFunc
 		err       error
@@ -102,7 +108,7 @@ func (w *manager) Watch(key string) {
 	for {
 		if watchChan == nil {
 			w.m.etcdWatchCreate.Inc(1)
-			watchChan, cancelFn, err = w.watchChanWithTimeout(key)
+			watchChan, cancelFn, err = w.watchChanWithTimeout(key, startRev)
 			if err != nil {
 				w.logger.Errorf("could not create etcd watch: %v", err)
 
@@ -139,6 +145,15 @@ func (w *manager) Watch(key string) {
 				w.m.etcdWatchError.Inc(1)
 				// do not stop here, even though the update contains an error
 				// we still take this chance to attempt a Get() for the latest value
+
+				// If the current revision has been compacted, set watchChan to
+				// nil so the watch is recreated with a valid start revision
+				if err == rpctypes.ErrCompacted {
+					w.logger.Warnf("recreating watch at revision %d", r.CompactRevision)
+					startRev = r.CompactRevision
+					watchChan = nil
+					continue
+				}
 			}
 
 			if err = w.updateFn(key, r.Events); err != nil {

--- a/etcd/watchmanager/manager.go
+++ b/etcd/watchmanager/manager.go
@@ -100,15 +100,15 @@ func (w *manager) Watch(key string) {
 	ticker := time.Tick(w.opts.WatchChanCheckInterval()) //nolint: megacheck
 
 	var (
-		startRev  int64
-		watchChan clientv3.WatchChan
-		cancelFn  context.CancelFunc
-		err       error
+		revOverride int64
+		watchChan   clientv3.WatchChan
+		cancelFn    context.CancelFunc
+		err         error
 	)
 	for {
 		if watchChan == nil {
 			w.m.etcdWatchCreate.Inc(1)
-			watchChan, cancelFn, err = w.watchChanWithTimeout(key, startRev)
+			watchChan, cancelFn, err = w.watchChanWithTimeout(key, revOverride)
 			if err != nil {
 				w.logger.Errorf("could not create etcd watch: %v", err)
 
@@ -150,7 +150,7 @@ func (w *manager) Watch(key string) {
 				// nil so the watch is recreated with a valid start revision
 				if err == rpctypes.ErrCompacted {
 					w.logger.Warnf("recreating watch at revision %d", r.CompactRevision)
-					startRev = r.CompactRevision
+					revOverride = r.CompactRevision
 					watchChan = nil
 				}
 			}

--- a/etcd/watchmanager/manager_test.go
+++ b/etcd/watchmanager/manager_test.go
@@ -248,6 +248,8 @@ func TestWatchCompactedRevision(t *testing.T) {
 	go wh.Watch("foo")
 	time.Sleep(3 * wh.opts.WatchChanInitTimeout())
 
+	assert.Equal(t, int32(4), atomic.LoadInt32(updateCalled))
+
 	lastRead := atomic.LoadInt32(updateCalled)
 	ec.Put(context.Background(), "foo", "bar-11")
 

--- a/etcd/watchmanager/manager_test.go
+++ b/etcd/watchmanager/manager_test.go
@@ -21,14 +21,17 @@
 package watchmanager
 
 import (
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/m3db/m3cluster/mocks"
+	"github.com/uber-go/tally"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/integration"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
@@ -37,7 +40,7 @@ func TestWatchChan(t *testing.T) {
 	wh, ec, _, _, _, closer := testSetup(t)
 	defer closer()
 
-	wc, _, err := wh.watchChanWithTimeout("foo")
+	wc, _, err := wh.watchChanWithTimeout("foo", 0)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(wc))
 
@@ -54,7 +57,7 @@ func TestWatchChan(t *testing.T) {
 	wh.opts = wh.opts.SetWatcher(mw).SetWatchChanInitTimeout(100 * time.Millisecond)
 
 	before := time.Now()
-	_, _, err = wh.watchChanWithTimeout("foo")
+	_, _, err = wh.watchChanWithTimeout("foo", 0)
 	require.WithinDuration(t, time.Now(), before, 150*time.Millisecond)
 	require.Error(t, err)
 }
@@ -216,6 +219,46 @@ func TestWatchNoLeader(t *testing.T) {
 
 	// clean up the background go routine
 	atomic.AddInt32(&shouldStop, 1)
+	<-doneCh
+}
+
+func TestWatchCompactedRevision(t *testing.T) {
+	wh, ec, updateCalled, shouldStop, doneCh, closer := testSetup(t)
+	defer closer()
+
+	ts := tally.NewTestScope("", nil)
+	errC := ts.Counter("errors")
+	wh.m.etcdWatchError = errC
+
+	var compactRev int64
+	for i := 1; i <= 10; i++ {
+		resp, err := ec.Put(context.Background(), "foo", fmt.Sprintf("bar-%d", i))
+		require.NoError(t, err)
+		compactRev = resp.Header.Revision
+	}
+
+	_, err := ec.Compact(context.Background(), compactRev)
+	require.NoError(t, err)
+
+	wh.opts = wh.opts.SetWatchOptions([]clientv3.OpOption{
+		clientv3.WithCreatedNotify(),
+		clientv3.WithRev(1),
+	})
+
+	go wh.Watch("foo")
+	time.Sleep(3 * wh.opts.WatchChanInitTimeout())
+
+	lastRead := atomic.LoadInt32(updateCalled)
+	ec.Put(context.Background(), "foo", "bar-11")
+
+	for atomic.LoadInt32(updateCalled) <= lastRead {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	errN := ts.Snapshot().Counters()["errors+"].Value()
+	assert.Equal(t, int64(1), errN, "expected to encounter watch error")
+
+	atomic.AddInt32(shouldStop, 1)
 	<-doneCh
 }
 

--- a/kv/etcd/options.go
+++ b/kv/etcd/options.go
@@ -74,6 +74,12 @@ type Options interface {
 	// SetWatchChanInitTimeout sets the WatchChanInitTimeout
 	SetWatchChanInitTimeout(t time.Duration) Options
 
+	// WatchStartRevision is the revision that watch requests will start from.
+	WatchStartRevision() int64
+	// SetWatchStartRevision sets the revision that watch requests will start
+	// from.
+	SetWatchStartRevision(rev int64) Options
+
 	// Prefix is the prefix for each key
 	Prefix() string
 	// SetPrefix sets the prefix
@@ -98,6 +104,7 @@ type options struct {
 	watchChanCheckInterval time.Duration
 	watchChanResetInterval time.Duration
 	watchChanInitTimeout   time.Duration
+	watchStartRevision     int64
 	cacheFileFn            CacheFileFn
 }
 
@@ -180,6 +187,15 @@ func (o options) WatchChanInitTimeout() time.Duration {
 
 func (o options) SetWatchChanInitTimeout(t time.Duration) Options {
 	o.watchChanInitTimeout = t
+	return o
+}
+
+func (o options) WatchStartRevision() int64 {
+	return o.watchStartRevision
+}
+
+func (o options) SetWatchStartRevision(rev int64) Options {
+	o.watchStartRevision = rev
 	return o
 }
 

--- a/kv/etcd/options.go
+++ b/kv/etcd/options.go
@@ -74,11 +74,12 @@ type Options interface {
 	// SetWatchChanInitTimeout sets the WatchChanInitTimeout
 	SetWatchChanInitTimeout(t time.Duration) Options
 
-	// WatchStartRevision is the revision that watch requests will start from.
-	WatchStartRevision() int64
-	// SetWatchStartRevision sets the revision that watch requests will start
+	// WatchWithRevision is the revision that watch requests will start from.
+	WatchWithRevision() int64
+
+	// SetWatchWithRevision sets the revision that watch requests will start
 	// from.
-	SetWatchStartRevision(rev int64) Options
+	SetWatchWithRevision(rev int64) Options
 
 	// Prefix is the prefix for each key
 	Prefix() string
@@ -104,7 +105,7 @@ type options struct {
 	watchChanCheckInterval time.Duration
 	watchChanResetInterval time.Duration
 	watchChanInitTimeout   time.Duration
-	watchStartRevision     int64
+	watchWithRevision      int64
 	cacheFileFn            CacheFileFn
 }
 
@@ -190,12 +191,12 @@ func (o options) SetWatchChanInitTimeout(t time.Duration) Options {
 	return o
 }
 
-func (o options) WatchStartRevision() int64 {
-	return o.watchStartRevision
+func (o options) WatchWithRevision() int64 {
+	return o.watchWithRevision
 }
 
-func (o options) SetWatchStartRevision(rev int64) Options {
-	o.watchStartRevision = rev
+func (o options) SetWatchWithRevision(rev int64) Options {
+	o.watchWithRevision = rev
 	return o
 }
 

--- a/kv/etcd/store.go
+++ b/kv/etcd/store.go
@@ -71,17 +71,24 @@ func NewStore(etcdKV clientv3.KV, etcdWatcher clientv3.Watcher, opts Options) (k
 			diskReadError:  scope.Counter("disk-read-error"),
 		},
 	}
+
+	clientWatchOpts := []clientv3.OpOption{
+		// periodically (appx every 10 mins) checks for the latest data
+		// with or without any update notification
+		clientv3.WithProgressNotify(),
+		// receive initial notification once the watch channel is created
+		clientv3.WithCreatedNotify(),
+	}
+
+	if rev := opts.WatchStartRevision(); rev > 0 {
+		clientWatchOpts = append(clientWatchOpts, clientv3.WithRev(rev))
+	}
+
 	wOpts := watchmanager.NewOptions().
 		SetWatcher(etcdWatcher).
 		SetUpdateFn(store.update).
 		SetTickAndStopFn(store.tickAndStop).
-		SetWatchOptions([]clientv3.OpOption{
-			// periodically (appx every 10 mins) checks for the latest data
-			// with or without any update notification
-			clientv3.WithProgressNotify(),
-			// receive initial notification once the watch channel is created
-			clientv3.WithCreatedNotify(),
-		}).
+		SetWatchOptions(clientWatchOpts).
 		SetWatchChanCheckInterval(opts.WatchChanCheckInterval()).
 		SetWatchChanInitTimeout(opts.WatchChanInitTimeout()).
 		SetWatchChanResetInterval(opts.WatchChanResetInterval()).

--- a/kv/etcd/store.go
+++ b/kv/etcd/store.go
@@ -80,7 +80,7 @@ func NewStore(etcdKV clientv3.KV, etcdWatcher clientv3.Watcher, opts Options) (k
 		clientv3.WithCreatedNotify(),
 	}
 
-	if rev := opts.WatchStartRevision(); rev > 0 {
+	if rev := opts.WatchWithRevision(); rev > 0 {
 		clientWatchOpts = append(clientWatchOpts, clientv3.WithRev(rev))
 	}
 

--- a/kv/etcd/store_test.go
+++ b/kv/etcd/store_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/m3db/m3cluster/generated/proto/kvtest"
 	"github.com/m3db/m3cluster/kv"
 	"github.com/m3db/m3cluster/mocks"
+
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
@@ -781,9 +782,9 @@ func TestTxn_UnknownType(t *testing.T) {
 	require.Equal(t, kv.ErrUnknownCompareType, err)
 }
 
-// Test that watching from 1) an old compacted start revision and 2) a start
-// revision in the future are both safe
-func TestStartRevision(t *testing.T) {
+// TestWatchWithStartRevision that watching from 1) an old compacted start
+// revision and 2) a start revision in the future are both safe
+func TestWatchWithStartRevision(t *testing.T) {
 	tests := map[string]int64{
 		"old_revision":    1,
 		"future_revision": 100000,
@@ -794,7 +795,7 @@ func TestStartRevision(t *testing.T) {
 			ec, opts, closeFn := testStore(t)
 			defer closeFn()
 
-			opts = opts.SetWatchStartRevision(rev)
+			opts = opts.SetWatchWithRevision(rev)
 
 			store, err := NewStore(ec, ec, opts)
 			require.NoError(t, err)

--- a/kv/etcd/store_test.go
+++ b/kv/etcd/store_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/m3db/m3cluster/kv"
 	"github.com/m3db/m3cluster/mocks"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestValue(t *testing.T) {
@@ -778,6 +779,47 @@ func TestTxn_UnknownType(t *testing.T) {
 		[]kv.Op{kv.NewSetOp("foo", genProto("bar1"))},
 	)
 	require.Equal(t, kv.ErrUnknownCompareType, err)
+}
+
+// Test that watching from 1) an old compacted start revision and 2) a start
+// revision in the future are both safe
+func TestStartRevision(t *testing.T) {
+	tests := map[string]int64{
+		"old_revision":    1,
+		"future_revision": 100000,
+	}
+
+	for name, rev := range tests {
+		t.Run(name, func(t *testing.T) {
+			ec, opts, closeFn := testStore(t)
+			defer closeFn()
+
+			opts = opts.SetWatchStartRevision(rev)
+
+			store, err := NewStore(ec, ec, opts)
+			require.NoError(t, err)
+
+			for i := 1; i <= 100; i++ {
+				_, err = store.Set("foo", genProto(fmt.Sprintf("bar-%d", i)))
+				require.NoError(t, err)
+			}
+
+			cl := store.(*client).kv
+
+			resp, err := cl.Get(context.Background(), "foo")
+			require.NoError(t, err)
+			compactRev := resp.Header.Revision
+
+			_, err = cl.Compact(context.Background(), compactRev-1)
+			require.NoError(t, err)
+
+			w1, err := store.Watch("foo")
+			require.NoError(t, err)
+			<-w1.C()
+			verifyValue(t, w1.Get(), "bar-100", 100)
+		})
+	}
+
 }
 
 func verifyValue(t *testing.T, v kv.Value, value string, version int) {


### PR DESCRIPTION
Some use cases require specifying the start revision of a watch request.
Since our only use case so far needs the start revision at a store level
as opposed to on a per-watch basis, this PR implements watch revision
support at the store level.

Includes tests to make sure that we can safely specify a start revision
that has been compacted or one that is in the future with no issues.