### PR TITLE
Add retry options for creating etcd client

### DIFF
--- a/client/etcd/options.go
+++ b/client/etcd/options.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"time"
 
 	"github.com/m3db/m3cluster/services"
@@ -41,8 +42,8 @@ const (
 
 	defaultRetryInitialBackoff = 2 * time.Second
 	defaultRetryBackoffFactor  = 2.0
-	defaultRetryMaxBackoff     = 4
 	defaultRetryMaxRetries     = 3
+	defaultRetryMaxBackoff     = time.Duration(math.MaxInt64)
 	defaultRetryJitter         = true
 )
 

--- a/client/etcd/types.go
+++ b/client/etcd/types.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/retry"
 )
 
 // Options is the Options to create a config service client.
@@ -51,6 +52,9 @@ type Options interface {
 
 	InstrumentOptions() instrument.Options
 	SetInstrumentOptions(iopts instrument.Options) Options
+
+	RetryOptions() retry.Options
+	SetRetryOptions(retryOpts retry.Options) Options
 
 	Validate() error
 }


### PR DESCRIPTION
When M3 processes using m3cluster for service discovery comes up, a lot of processes will log a fatal error message and fail if they cannot start up.  

This is fine but can cause a large amount of DNS requests to be issued if restarted by a processes supervisor very frequently.  To avoid some of these thundering herd issues if a KV client is down, we add some level of backoff when trying to connect to service discovery.